### PR TITLE
Fix spelling in option description and man page

### DIFF
--- a/man/pcb2gcode.1
+++ b/man/pcb2gcode.1
@@ -288,7 +288,7 @@ relevant only when \fB\-\-software\fP=\fBcustom\fP
 
 .PP
 \fBpcb2gcode\fP can repeat the PCB in a tile-x times tile-y grid of identical
-PCBs. This feature can be activated by specifing the number of columns and rows
+PCBs. This feature can be activated by specifying the number of columns and rows
 with \fB\-\-tile\-x\fP and \fB\-\-tile\-y\fP. If you don't specify a software,
 or if you use \fB\-\-software=Custom\fP, the resulting Gcode will be much bigger
 (about original_size * tile-x * tile-y).
@@ -309,7 +309,7 @@ cutoffs (like thermal pads). When \fB\-\-vectorial\fP is enabled, \fB\-\-dpi\fP
 is ignored.
 .TP
 \fB\-\-software\fP \fIsoftware\fP
-specify the gcode interpreter software; currently supported softwares are
+specify the gcode interpreter software; currently supported programs are
 \fBLinuxCNC\fP, \fBMach3\fP, \fBMach4\fP and \fBcustom\fP. With custom you
 can specify \fBal-probecode\fP, \fBal-probevar\fP and \fBal-setzzero\fP, in
 order to generate gcode for an unsupported software.

--- a/options.cpp
+++ b/options.cpp
@@ -258,7 +258,7 @@ options::options()
             "enable the z autoleveller for the front layer")(
             "al-back", po::value<bool>()->default_value(false)->implicit_value(true),
             "enable the z autoleveller for the back layer")(
-            "software", po::value<string>(), "choose the destination software (useful only with the autoleveller). Supported softwares are linuxcnc, mach3, mach4 and custom")(
+            "software", po::value<string>(), "choose the destination software (useful only with the autoleveller). Supported programs are linuxcnc, mach3, mach4 and custom")(
             "al-x", po::value<double>(), "width of the x probes")(
             "al-y", po::value<double>(), "width of the y probes")(
             "al-probefeed", po::value<double>(), "speed during the probing")(


### PR DESCRIPTION
"specifing" -> "specifying", "softwares" -> "programs" (some other expressions would do as well, but software has no plural in English). Both were found by the Debian package checker lintian.