### PR TITLE
Milldrill diameter (--milldrill-diameter option)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -430,6 +430,9 @@ int main(int argc, char* argv[])
 
         if (vm["milldrill"].as<bool>())
         {
+            if (vm.count("milldrill-diameter")) {
+                cutter->tool_diameter = vm["milldrill-diameter"].as<double>() * unit;
+            }
             ep.export_ngc( build_filename(outputdir, vm["drill-output"].as<string>()), cutter);
         }
         else

--- a/man/pcb2gcode.1
+++ b/man/pcb2gcode.1
@@ -142,6 +142,10 @@ regularly (possibly creating a bigger hole than intended), the other holes are
 created by moving the head in circles using the feed and infeed parameters used
 in cutting.
 .TP
+\fB\-\-milldrill-diameter\fP \fIunit\fP
+diameter of milling head which is used with \fB\-\-milldrill\fP;
+the default value is same as \fB\-\-cutter\-diameter\fP.
+.TP
 \fB\-\-drill\-side\fP \fIside\fP
 choose the drill side. Valid choices are front, back or auto (default). In auto
 mode the drill side is automatically chosen (always front unless only the back

--- a/options.cpp
+++ b/options.cpp
@@ -226,6 +226,7 @@ options::options()
             "mill-vertfeed", po::value<double>(), "vertical feed while isolating in [i/m] or [mm/m]")(
             "mill-speed", po::value<int>(), "spindle rpm when milling")(
             "milldrill", po::value<bool>()->default_value(false)->implicit_value(true), "drill using the mill head")(
+            "milldrill-diameter", po::value<double>(), "diameter of the end mill used for drilling with --milldrill")(
             "nog81", po::value<bool>()->default_value(false)->implicit_value(true), "replace G81 with G0+G1")(
             "nog91-1", po::value<bool>()->default_value(false)->implicit_value(true), "do not explicitly set G91.1 in drill headers")(
             "extra-passes", po::value<int>()->default_value(0), "specify the the number of extra isolation passes, increasing the isolation width half the tool diameter with each pass")(


### PR DESCRIPTION
With --milldrill option, pcb2gcode uses --cutter-diameter to both drilling and cutting outline.

I want to use different diameter endmill for drilling and cutting (Eg. φ0.8mm for milldrill and φ2mm for cutting). So this patch adds --milldrill-diameter option which override diameter of cutter of drilling.