### PR TITLE
New build_voronoi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.exe
 *.out
 *.app
+*_test
 
 #built or generated project files
 .deps/*
@@ -47,6 +48,7 @@ m4/missing
 m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
+m4/test-driver
 man/Makefile
 man/Makefile.in
 pcb2gcode
@@ -54,6 +56,12 @@ stamp-h1
 testing/gerbv_example/*/*.png
 testing/gerbv_example/*/*.ngc
 testing/gerbv_example/*/*.svg
+
+#make check output files
+*.log
+*.trs
+*_input.svg
+*_output.svg
 
 #editor or browser files
 .directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ script:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then ./configure --disable-dependency-tracking --disable-silent-rules; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then ./configure --disable-dependency-tracking --disable-silent-rules --with-boost=$BOOST_DIR --enable-static-boost; fi
   - make
+  - make check
 
 after_script:
   - cd testing/gerbv_example/

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,3 +49,8 @@ AM_LDFLAGS = $(BOOST_PROGRAM_OPTIONS_LDFLAGS)
 LIBS = $(glibmm_LIBS) $(gdkmm_LIBS) $(gerbv_LIBS) $(BOOST_PROGRAM_OPTIONS_LIBS)
 
 EXTRA_DIST = millproject
+
+check_PROGRAMS = voronoi_tests
+voronoi_tests_SOURCES = voronoi.hpp voronoi.cpp voronoi_tests.cpp
+
+TESTS = voronoi_tests

--- a/voronoi.cpp
+++ b/voronoi.cpp
@@ -19,8 +19,6 @@
 
 #include "voronoi.hpp"
 #include "voronoi_visual_utils.hpp"
-#include <boost/variant.hpp>
-#include <boost/optional.hpp>
 #include <list>
 #include <map>
 #include <algorithm>

--- a/voronoi.cpp
+++ b/voronoi.cpp
@@ -234,7 +234,7 @@ void Voronoi::clip_infinite_edge(
     }
     coordinate_type side = bounding_box.max_corner().x() - bounding_box.min_corner().x();
     coordinate_type koef =
-        side / (std::max)(fabs(direction.x()), fabs(direction.y()));
+        side / (std::max)(abs(direction.x()), abs(direction.y()));
     if (edge.vertex0() == NULL) {
         clipped_edge->push_back(point_type_fp_p(
                                     origin.x() - direction.x() * koef,

--- a/voronoi.hpp
+++ b/voronoi.hpp
@@ -21,7 +21,6 @@
 #define VORONOI_H
 
 #include <boost/polygon/voronoi.hpp>
-#include <boost/optional.hpp>
 
 #include <vector>
 using std::vector;
@@ -61,7 +60,6 @@ typedef voronoi_diagram_type::cell_type cell_type;
 typedef voronoi_diagram_type::cell_type::source_index_type source_index_type;
 typedef voronoi_diagram_type::cell_type::source_category_type source_category_type;
 typedef voronoi_diagram_type::edge_type edge_type;
-typedef voronoi_diagram_type::vertex_type vertex_type;
 typedef voronoi_diagram_type::cell_container_type cell_container_type;
 typedef voronoi_diagram_type::cell_container_type vertex_container_type;
 typedef voronoi_diagram_type::edge_container_type edge_container_type;
@@ -72,10 +70,13 @@ typedef voronoi_diagram_type::const_edge_iterator const_edge_iterator;
 class Voronoi
 {
 public:
-    /* The returned rings are loops around the input polygons that
-     * follow the voronoi diagram.  The loops might extend outside the
-     * bounding_box provided.  The loops don't overlap and will
-     * together cover at least the entire bounding_box.
+    /* The returned polygon are voronoi regaions around the input
+     * polygons that follow the voronoi diagram.  The loops might
+     * extend outside the bounding_box provided.  The loops don't
+     * overlap and will together cover at least the entire
+     * bounding_box.  The order and number of outputs is the same as
+     * the order and number of inputs but the number of inner rings on
+     * each output might not match those of the corresponding input.
      */
     static multi_polygon_type_fp build_voronoi(
         const multi_polygon_type& input,

--- a/voronoi.hpp
+++ b/voronoi.hpp
@@ -21,6 +21,7 @@
 #define VORONOI_H
 
 #include <boost/polygon/voronoi.hpp>
+#include <boost/optional.hpp>
 
 #include <vector>
 using std::vector;
@@ -60,6 +61,7 @@ typedef voronoi_diagram_type::cell_type cell_type;
 typedef voronoi_diagram_type::cell_type::source_index_type source_index_type;
 typedef voronoi_diagram_type::cell_type::source_category_type source_category_type;
 typedef voronoi_diagram_type::edge_type edge_type;
+typedef voronoi_diagram_type::vertex_type vertex_type;
 typedef voronoi_diagram_type::cell_container_type cell_container_type;
 typedef voronoi_diagram_type::cell_container_type vertex_container_type;
 typedef voronoi_diagram_type::edge_container_type edge_container_type;
@@ -70,17 +72,26 @@ typedef voronoi_diagram_type::const_edge_iterator const_edge_iterator;
 class Voronoi
 {
 public:
-    static unique_ptr<multi_polygon_type> build_voronoi(const multi_polygon_type& input,
-                                coordinate_type bounding_box_offset, coordinate_type max_dist);
+    /* The returned rings are loops around the input polygons that
+     * follow the voronoi diagram.  The loops might extend outside the
+     * bounding_box provided.  The loops don't overlap and will
+     * together cover at least the entire bounding_box.
+     */
+    static multi_polygon_type_fp build_voronoi(
+        const multi_polygon_type& input,
+        const box_type& bounding_box, coordinate_type max_dist);
 
 protected:
-    static pair<const polygon_type *,ring_type *> find_ring (const multi_polygon_type& input,
-                                                             const cell_type& cell, multi_polygon_type& output);
+    static linestring_type_fp edge_to_linestring(const edge_type& edge, const vector<segment_type_p>& segments, const box_type_fp& bounding_box, coordinate_type max_dist);
+    static void copy_ring(const ring_type& ring, vector<segment_type_p> &segments);
     static point_type_p retrieve_point(const cell_type& cell, const vector<segment_type_p> &segments);
     static const segment_type_p& retrieve_segment(const cell_type& cell, const vector<segment_type_p> &segments);
     static void sample_curved_edge(const edge_type *edge, const vector<segment_type_p> &segments,
-                                    vector<point_type_fp_p>& sampled_edge, coordinate_type_fp max_dist);
-    static void copy_ring(const ring_type& ring, vector<segment_type_p> &segments);
+                                   vector<point_type_fp_p>& sampled_edge, coordinate_type_fp max_dist);
+    static void clip_infinite_edge(
+        const edge_type& edge, const vector<segment_type_p>& segments, std::vector<point_type_fp_p>* clipped_edge, const box_type_fp& bounding_box);
+    // Do these edges belong to the same polygon?
+    static bool same_poly(const edge_type& edge0, const edge_type& edge1, const std::vector<size_t>& segments_to_poly);
 };
 
 #endif

--- a/voronoi_tests.cpp
+++ b/voronoi_tests.cpp
@@ -1,0 +1,82 @@
+#define BOOST_TEST_MODULE voronoi tests
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/format.hpp>
+#include "voronoi.hpp"
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(voronoi_tests);
+
+// Output SVG files for debugging.
+#define DEBUG_SVG TRUE
+
+template <typename geo_t>
+void print_svg(const geo_t& geo, const string& filename) {
+  std::ofstream svg(filename);
+
+  box_type bounding_box;
+  bg::envelope(geo, bounding_box);
+  bg::svg_mapper<point_type> mapper(svg,
+                                    bounding_box.max_corner().x() - bounding_box.min_corner().x(),
+                                    bounding_box.max_corner().y() - bounding_box.min_corner().y());
+  srand(1);
+  for (const auto& g : geo) {
+    mapper.add(g);
+    mapper.map(g, (boost::format("opacity:1;fill:rgb(%d,%d,%d);stroke:rgb(0,0,0);stroke-width:2")
+                   % (rand()%255)
+                   % (rand()%255)
+                   % (rand()%255)).str());
+  }
+}
+
+BOOST_AUTO_TEST_CASE(empty) {
+  multi_polygon_type mp;
+  const auto& result = Voronoi::build_voronoi(mp, 10, 10);
+  BOOST_CHECK(result->size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(just_a_square) {
+  multi_polygon_type mp;
+  polygon_type new_poly;
+  bg::read_wkt("POLYGON((0 0, 0 100, 100 100, 100 0, 0 0))", new_poly);
+  mp.push_back(new_poly);
+  print_svg(mp, "just_a_square_input.svg");
+  const auto& result = Voronoi::build_voronoi(mp, 1000, 1000);
+  print_svg(*result, "just_a_square_output.svg");
+  BOOST_CHECK(result->size() == 1);
+}
+
+BOOST_AUTO_TEST_CASE(square_with_hole) {
+  multi_polygon_type mp;
+  polygon_type new_poly;
+  bg::read_wkt("POLYGON((0 0, 0 100, 100 100, 100 0, 0 0),(50 20, 80 50, 50 80, 20 50, 50 20))", new_poly);
+  mp.push_back(new_poly);
+  new_poly.clear();
+  bg::read_wkt("POLYGON((45 45, 45 55, 55 55, 55 45, 45 45))", new_poly);
+  mp.push_back(new_poly);
+  print_svg(mp, "square_with_hole_input.svg");
+  const auto& result = Voronoi::build_voronoi(mp, 100, 100);
+  print_svg(*result, "square_with_hole_output.svg");
+  BOOST_CHECK(result->size() == 2);
+  BOOST_CHECK((*result)[0].inners().size() == 1);
+  BOOST_CHECK((*result)[1].inners().size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(almost_square_with_hole) {
+  multi_polygon_type mp;
+  polygon_type new_poly;
+  bg::read_wkt("POLYGON((0 0, 0 100, 100 100, 100 55, 80 55, 50 80, 20 50, 50 20, 100 45, 100 0, 0 0))", new_poly);
+  mp.push_back(new_poly);
+  new_poly.clear();
+  bg::read_wkt("POLYGON((45 45, 45 55, 55 55, 55 45, 45 45))", new_poly);
+  mp.push_back(new_poly);
+  print_svg(mp, "square_with_hole_input.svg");
+  const auto& result = Voronoi::build_voronoi(mp, 100, 100);
+  print_svg(*result, "square_with_hole_output.svg");
+  BOOST_CHECK(result->size() == 2);
+  BOOST_CHECK((*result)[0].inners().size() == 0);
+  BOOST_CHECK((*result)[1].inners().size() == 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/voronoi_tests.cpp
+++ b/voronoi_tests.cpp
@@ -32,8 +32,10 @@ void print_svg(const geo_t& geo, const string& filename) {
 
 BOOST_AUTO_TEST_CASE(empty) {
   multi_polygon_type mp;
-  const auto& result = Voronoi::build_voronoi(mp, 10, 10);
-  BOOST_CHECK(result->size() == 0);
+  box_type bounding_box;
+  bg::envelope(mp, bounding_box);
+  const auto& result = Voronoi::build_voronoi(mp, bounding_box, 10);
+  BOOST_CHECK(result.size() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(just_a_square) {
@@ -42,9 +44,11 @@ BOOST_AUTO_TEST_CASE(just_a_square) {
   bg::read_wkt("POLYGON((0 0, 0 100, 100 100, 100 0, 0 0))", new_poly);
   mp.push_back(new_poly);
   print_svg(mp, "just_a_square_input.svg");
-  const auto& result = Voronoi::build_voronoi(mp, 1000, 1000);
-  print_svg(*result, "just_a_square_output.svg");
-  BOOST_CHECK(result->size() == 1);
+  box_type bounding_box;
+  bg::envelope(mp, bounding_box);
+  const auto& result = Voronoi::build_voronoi(mp, bounding_box, 10);
+  print_svg(result, "just_a_square_output.svg");
+  BOOST_CHECK(result.size() == 1);
 }
 
 BOOST_AUTO_TEST_CASE(square_with_hole) {
@@ -56,11 +60,13 @@ BOOST_AUTO_TEST_CASE(square_with_hole) {
   bg::read_wkt("POLYGON((45 45, 45 55, 55 55, 55 45, 45 45))", new_poly);
   mp.push_back(new_poly);
   print_svg(mp, "square_with_hole_input.svg");
-  const auto& result = Voronoi::build_voronoi(mp, 100, 100);
-  print_svg(*result, "square_with_hole_output.svg");
-  BOOST_CHECK(result->size() == 2);
-  BOOST_CHECK((*result)[0].inners().size() == 1);
-  BOOST_CHECK((*result)[1].inners().size() == 0);
+  box_type bounding_box;
+  bg::envelope(mp, bounding_box);
+  const auto& result = Voronoi::build_voronoi(mp, bounding_box, 10);
+  print_svg(result, "square_with_hole_output.svg");
+  BOOST_CHECK(result.size() == 2);
+  BOOST_CHECK(result[0].inners().size() == 1);
+  BOOST_CHECK(result[1].inners().size() == 0);
 }
 
 BOOST_AUTO_TEST_CASE(almost_square_with_hole) {
@@ -72,11 +78,13 @@ BOOST_AUTO_TEST_CASE(almost_square_with_hole) {
   bg::read_wkt("POLYGON((45 45, 45 55, 55 55, 55 45, 45 45))", new_poly);
   mp.push_back(new_poly);
   print_svg(mp, "square_with_hole_input.svg");
-  const auto& result = Voronoi::build_voronoi(mp, 100, 100);
-  print_svg(*result, "square_with_hole_output.svg");
-  BOOST_CHECK(result->size() == 2);
-  BOOST_CHECK((*result)[0].inners().size() == 0);
-  BOOST_CHECK((*result)[1].inners().size() == 0);
+  box_type bounding_box;
+  bg::envelope(mp, bounding_box);
+  const auto& result = Voronoi::build_voronoi(mp, bounding_box, 10);
+  print_svg(result, "square_with_hole_output.svg");
+  BOOST_CHECK(result.size() == 2);
+  BOOST_CHECK(result[0].inners().size() == 1);
+  BOOST_CHECK(result[1].inners().size() == 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The new build_voronoi routine solves the problem described here: https://github.com/pcb2gcode/pcb2gcode/pull/79#issuecomment-353953181

I also added a unit test for build_voronoi.  The test can be run at https://github.com/pcb2gcode/pcb2gcode/commit/e46fb27b43b2aad18e6316003eb7cd1dc8e97b0d and then at https://github.com/pcb2gcode/pcb2gcode/commit/1964032805fdfdf4ea3a8917122e16681f5d7ace and the generated svg outputs compared, showing how it solves the problem.

The difference can be seen here, the new is on the left, the old on the right:
![image](https://user-images.githubusercontent.com/109809/34455379-b04e9270-ed86-11e7-8e2f-9cb4be18a7fa.png)

In the center and in the top left of the old image, there is a little voronoi line that divides two copper sections that are connected together elsewhere.