### PR TITLE
Eulerian paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@
 *.exe
 *.out
 *.app
-*_test
+*_tests
 
 #built or generated project files
 .deps/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update && brew reinstall -s libtool && brew outdated boost || brew upgrade boost && brew install gtkmm gerbv; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget https://sourceforge.net/projects/pcb2gcode/files/pcb2gcode/boost_1_56_0_amd64.tar.gz && tar -xf boost_1_56_0_amd64.tar.gz && export BOOST_DIR=$PWD/boost_1_56_0_amd64; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget https://github.com/eyal0/pcb2gcode/releases/download/1.3.3/boost_1_65_1_amd64.tar.gz && tar -xf boost_1_65_1_amd64.tar.gz && export BOOST_DIR=$PWD/boost_1_65_1_amd64; fi
 
 install:
   - export CXX=$COMPILER

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ pcb2gcode_SOURCES = \
     core.cpp \
     drill.hpp \
     drill.cpp \
+    eulerian_paths.hpp \
     exporter.hpp \
     Fixed.hpp \
     geometry.hpp \
@@ -24,6 +25,7 @@ pcb2gcode_SOURCES = \
     mill.hpp \
     ngc_exporter.hpp \
     ngc_exporter.cpp \
+    segmentize.hpp \
     surface.hpp \
     surface.cpp \
     surface_vectorial.hpp \
@@ -50,7 +52,9 @@ LIBS = $(glibmm_LIBS) $(gdkmm_LIBS) $(gerbv_LIBS) $(BOOST_PROGRAM_OPTIONS_LIBS)
 
 EXTRA_DIST = millproject
 
-check_PROGRAMS = voronoi_tests
+check_PROGRAMS = voronoi_tests eulerian_paths_tests segmentize_tests
 voronoi_tests_SOURCES = voronoi.hpp voronoi.cpp voronoi_tests.cpp
+eulerian_paths_tests_SOURCES = eulerian_paths_tests.cpp
+segmentize_tests_SOURCES = segmentize_tests.cpp
 
-TESTS = voronoi_tests
+TESTS = $(check_PROGRAMS)

--- a/eulerian_paths.hpp
+++ b/eulerian_paths.hpp
@@ -1,0 +1,167 @@
+#ifndef EULERIAN_PATHS_H
+#define EULERIAN_PATHS_H
+
+#include <vector>
+#include <map>
+
+#include "geometry.hpp"
+
+/* This finds a minimal number of eulerian paths that cover the input.
+ * The number of paths returned is equal to the number of vertices
+ * with odd edge count divided by 2.
+ *
+ * To use, first get paths.  Each path is a vector of n points that
+ * represents n-1 line segments.  Each path is considerd
+ * bidirectional.
+ *
+ * After adding paths, build the Eulerian paths.  The resulting paths
+ * cover all segments in the input paths with the minimum number of
+ * paths as described above.
+ */
+
+namespace eulerian_paths {
+
+bool operator !=(const point_type& x, const point_type& y) {
+  return std::tie(x.x(), x.y()) != std::tie(y.x(), y.y());
+}
+
+bool operator ==(const point_type& x, const point_type& y) {
+  return std::tie(x.x(), x.y()) == std::tie(y.x(), y.y());
+}
+
+bool operator !=(const point_type_fp& x, const point_type_fp& y) {
+  return std::tie(x.x(), x.y()) != std::tie(y.x(), y.y());
+}
+
+bool operator ==(const point_type_fp& x, const point_type_fp& y) {
+  return std::tie(x.x(), x.y()) == std::tie(y.x(), y.y());
+}
+
+template <typename point_t, typename linestring_t, typename multi_linestring_t, typename point_less_than_p = std::less<point_t>>
+multi_linestring_t get_eulerian_paths(const multi_linestring_t& paths) {
+  // Create a map from vertex to each path that starts or ends (or
+  // both) at that vertex.  It's a map to an input into the input
+  // paths.
+  std::multimap<point_t, size_t, point_less_than_p> vertex_to_unvisited_path_index;
+  for (size_t i = 0; i < paths.size(); i++) {
+    auto& path = paths[i];
+    if (path.size() < 2) {
+      // Valid path must have a start and end.
+      continue;
+    }
+    point_t start = path.front();
+    point_t end = path.back();
+    vertex_to_unvisited_path_index.emplace(start, i);
+    vertex_to_unvisited_path_index.emplace(end, i);
+  }
+
+  // Given a point, make a path from that point as long as possible
+  // until a dead end.  Assume that point itself is already in the
+  // list.
+  std::function<void(const point_t&, linestring_t*)> make_path = [&] (const point_t& point, linestring_t* new_path) -> void {
+    // Find an unvisited path that leads from point, any will do.
+    auto vertex_and_path_index = vertex_to_unvisited_path_index.find(point);
+    if (vertex_and_path_index == vertex_to_unvisited_path_index.end()) {
+      // No more paths to follow.
+      return;
+    }
+    size_t path_index = vertex_and_path_index->second;
+    auto& path = paths[path_index];
+    if (point == path.front()) {
+      // Append this path in the forward direction.
+      new_path->insert(new_path->end(), path.cbegin()+1, path.cend());
+    } else {
+      // Append this path in the reverse direction.
+      new_path->insert(new_path->end(), path.crbegin()+1, path.crend());
+    }
+    vertex_to_unvisited_path_index.erase(vertex_and_path_index); // Remove from the first vertex.
+    point_t& new_point = new_path->back();
+    // We're bound to find one, otherwise there is a serious error in
+    // the algorithm.
+    auto range = vertex_to_unvisited_path_index.equal_range(new_point);
+    for (auto iter = range.first; iter != range.second; iter++) {
+      if (iter->second == path_index) {
+        // Remove the path from the last vertex
+        vertex_to_unvisited_path_index.erase(iter);
+        break;
+      }
+    }
+    // Continue making the path from here.
+    make_path(new_point, new_path);
+  };
+
+  // Only call this when there are no vertices with odd edge count.
+  // This will traverse a path and, if it finds an unvisited edge,
+  // will make a Euler circuit there and stitch it into the current
+  // path.  This continues until the end of the path.
+  auto stitch_loops = [&] (linestring_t *euler_path) -> void {
+    for (size_t i = 0; i < euler_path->size(); i++) {
+      // Does this vertex have any unvisited edges?
+      if (vertex_to_unvisited_path_index.count((*euler_path)[i]) > 0) {
+        // Make a path from here.  We don't need the first element, it's already in our path.
+        linestring_t new_loop{};
+        make_path((*euler_path)[i], &new_loop);
+        // Now we stitch it in.
+        euler_path->insert(euler_path->begin()+i+1, new_loop.begin(), new_loop.end());
+      }
+    }
+  };
+
+  // We use Hierholzer's algorithm to find the minimum cycles.  First,
+  // make a path from each vertex with odd path count until the path
+  // ends.
+  std::vector<point_t> odd_vertices;
+  // First find all vertices with odd count.  We do it separate from
+  // the loop below because the below loop will modify
+  // vertex_to_unvisited_path_index and invalidate the iterator.
+  for (auto iter = vertex_to_unvisited_path_index.cbegin();
+       iter != vertex_to_unvisited_path_index.cend();) {
+    auto& vertex = iter->first;
+    if (vertex_to_unvisited_path_index.count(vertex) % 2 == 1) {
+      odd_vertices.push_back(vertex);
+    }
+    // Advance to a different vertex.
+    iter = vertex_to_unvisited_path_index.upper_bound(vertex);
+  }
+
+  multi_linestring_t euler_paths{};
+  for (auto iter = odd_vertices.cbegin(); iter != odd_vertices.cend(); iter++) {
+    auto& vertex = *iter;
+    // We check again because it might have become even after being
+    // connected to a different path.
+    if (vertex_to_unvisited_path_index.count(vertex) % 2 == 1) {
+      // Make a path starting from vertex with odd count.
+      linestring_t new_path;
+      new_path.push_back(vertex);
+      make_path(vertex, &new_path);
+      euler_paths.push_back(new_path);
+    }
+  }
+
+  // At this point, all remaining vertices have an even number of
+  // edges.  So if we make a path from one, it is sure to end back
+  // where it started.  We'll go over all our current Euler paths and
+  // stitch in loops anywhere that there is an unvisited edge.
+  for (auto& euler_path : euler_paths) {
+    stitch_loops(&euler_path);
+  }
+
+  // Anything remaining is on islands.  Make all those paths, too.  No
+  // stitching needed because all vertices have an even number of
+  // edges.
+  while(vertex_to_unvisited_path_index.size() > 0) {
+    const auto vertex = vertex_to_unvisited_path_index.cbegin()->first;
+    linestring_t new_path;
+    new_path.push_back(vertex);
+    make_path(vertex, &new_path);
+    // We can stitch right now because all vertices already have
+    // even number of edges.
+    stitch_loops(&new_path);
+    euler_paths.push_back(new_path);
+  }
+
+  return euler_paths;
+}
+
+} //namespace eulerian_paths
+#endif //EULERIAN_PATHS_H

--- a/eulerian_paths_tests.cpp
+++ b/eulerian_paths_tests.cpp
@@ -1,0 +1,144 @@
+#define BOOST_TEST_MODULE eulerian paths tests
+#include <boost/test/included/unit_test.hpp>
+
+#include "eulerian_paths.hpp"
+
+using std::vector;
+using namespace eulerian_paths;
+
+BOOST_AUTO_TEST_SUITE(eulerian_paths_tests);
+
+struct PointLessThan {
+  bool operator()(const point_type& a, const point_type& b) const {
+    return std::tie(a.x(), a.y()) < std::tie(b.x(), b.y());
+  }
+};
+
+BOOST_AUTO_TEST_CASE(do_nothing_points) {
+  BOOST_CHECK(0==0);
+  get_eulerian_paths<point_type, linestring_type, multi_linestring_type, PointLessThan>({{{1,1},{2,2},{3,3}}});
+}
+
+// 3x3 grid connected like a window pane:
+// 1---2---3
+// |   |   |
+// 4---5---6
+// |   |   |
+// 7---8---9
+BOOST_AUTO_TEST_CASE(window_pane) {
+  BOOST_CHECK(0==0);
+  vector<vector<int>> euler_paths = get_eulerian_paths<int, vector<int>, vector<vector<int>>>({
+      {1,2},
+      {2,3},
+      {4,5},
+      {5,6},
+      {7,8},
+      {8,9},
+      {1,4},
+      {4,7},
+      {2,5},
+      {5,8},
+      {3,6},
+      {6,9},
+          });
+  int edges_visited = 0;
+  for (size_t i = 0; i < euler_paths.size(); i++) {
+    edges_visited += euler_paths[i].size()-1;
+    for (size_t j = 0; j < euler_paths[i].size(); j++) {
+      printf("%d ", euler_paths[i][j]);
+    }
+    printf("\n");
+  }
+  BOOST_CHECK(edges_visited == 12);
+  BOOST_CHECK(euler_paths.size() == 2);
+}
+
+// 3x3 grid connected like a window pane, but corners are longer paths:
+// 1---2---3
+// |   |   |
+// 4---5---6
+// |   |   |
+// 7---8---9
+BOOST_AUTO_TEST_CASE(window_pane_with_longer_corners) {
+  BOOST_CHECK(0==0);
+  vector<vector<int>> euler_paths = get_eulerian_paths<int, vector<int>, vector<vector<int>>>({
+      {4,5},
+      {5,6},
+      {4,7,8},
+      {2,5},
+      {5,8},
+      {6,9,8},
+      {4,1,2},
+      {2,3,6},
+          });
+  int edges_visited = 0;
+  for (size_t i = 0; i < euler_paths.size(); i++) {
+    edges_visited += euler_paths[i].size()-1;
+    for (size_t j = 0; j < euler_paths[i].size(); j++) {
+      printf("%d ", euler_paths[i][j]);
+    }
+    printf("\n");
+  }
+  BOOST_CHECK(edges_visited == 12);
+  BOOST_CHECK(euler_paths.size() == 2);
+}
+
+// Bridge
+// 5---2---1---6
+// |   |   |   |
+// 3---4   7---8
+BOOST_AUTO_TEST_CASE(bridge) {
+  BOOST_CHECK(0==0);
+  vector<vector<int>> euler_paths = get_eulerian_paths<int, vector<int>, vector<vector<int>>>({
+      {5,2},
+      {2,1},
+      {1,6},
+      {3,4},
+      {7,8},
+      {5,3},
+      {2,4},
+      {1,7},
+      {6,8},
+          });
+  int edges_visited = 0;
+  for (size_t i = 0; i < euler_paths.size(); i++) {
+    edges_visited += euler_paths[i].size()-1;
+    for (size_t j = 0; j < euler_paths[i].size(); j++) {
+      printf("%d ", euler_paths[i][j]);
+    }
+    printf("\n");
+  }
+  BOOST_CHECK(edges_visited == 9);
+  BOOST_CHECK(euler_paths.size() == 1);
+}
+
+// Disjoint Loops
+// 5---2   1---6  0---9
+// |   |   |   |
+// 3---4   7---8
+BOOST_AUTO_TEST_CASE(disjoint_loops) {
+  BOOST_CHECK(0==0);
+  vector<vector<int>> euler_paths = get_eulerian_paths<int, vector<int>, vector<vector<int>>>({
+      {5,2},
+      {1,6},
+      {3,4},
+      {7,8},
+      {5,3},
+      {2,4},
+      {1,7},
+      {6,8},
+      {0,9},
+          });
+  int edges_visited = 0;
+  for (size_t i = 0; i < euler_paths.size(); i++) {
+    edges_visited += euler_paths[i].size()-1;
+    for (size_t j = 0; j < euler_paths[i].size(); j++) {
+      printf("%d ", euler_paths[i][j]);
+    }
+    printf("\n");
+  }
+  BOOST_CHECK(edges_visited == 9);
+  BOOST_CHECK(euler_paths.size() == 3);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/main.cpp
+++ b/main.cpp
@@ -111,6 +111,7 @@ int main(int argc, char* argv[])
         isolator->zchange = vm["zchange"].as<double>() * unit;
         isolator->extra_passes = vm["extra-passes"].as<int>();
         isolator->optimise = vm["optimise"].as<bool>();
+        isolator->eulerian_paths = vm["eulerian-paths"].as<bool>();
         isolator->tolerance = tolerance;
         isolator->explicit_tolerance = explicit_tolerance;
         isolator->mirror_absolute = vm["mirror-absolute"].as<bool>();
@@ -134,6 +135,7 @@ int main(int argc, char* argv[])
         cutter->do_steps = true;
         cutter->stepsize = vm["cut-infeed"].as<double>() * unit;
         cutter->optimise = vm["optimise"].as<bool>();
+        isolator->eulerian_paths = vm["eulerian-paths"].as<bool>();
         cutter->tolerance = tolerance;
         cutter->explicit_tolerance = explicit_tolerance;
         cutter->mirror_absolute = vm["mirror-absolute"].as<bool>();

--- a/mill.hpp
+++ b/mill.hpp
@@ -56,6 +56,7 @@ class RoutingMill: public Mill
 public:
     double tool_diameter;
     bool optimise;
+    bool eulerian_paths;
 };
 
 /******************************************************************************/

--- a/ngc_exporter.hpp
+++ b/ngc_exporter.hpp
@@ -67,11 +67,6 @@ public:
 
 protected:
     void export_layer(shared_ptr<Layer> layer, string of_name);
-    inline bool aligned(icoords::const_iterator p0, icoords::const_iterator p1, icoords::const_iterator p2)
-    {
-        return ( (p0->first == p1->first) && (p1->first == p2->first) ) ||      //x-aligned
-               ( (p0->second == p1->second) && (p1->second == p2->second) );    //y-aligned
-    }
 
     shared_ptr<Board> board;
     vector<string> header;

--- a/options.cpp
+++ b/options.cpp
@@ -251,6 +251,7 @@ options::options()
             "metric", po::value<bool>()->default_value(false)->implicit_value(true), "use metric units for parameters. does not affect gcode output")(
             "metricoutput", po::value<bool>()->default_value(false)->implicit_value(true), "use metric units for output")(
             "optimise", po::value<bool>()->default_value(true)->implicit_value(true), "Reduce output file size by up to 40% while accepting a little loss of precision (enabled by default).")(
+            "eulerian-paths", po::value<bool>()->default_value(true)->implicit_value(true), "Don't mill the same path twice if milling loops overlap.  This can save up to 50% of milling time.  Enabled by default.")(
             "bridges", po::value<double>()->default_value(0), "add bridges with the given width to the outline cut")(
             "bridgesnum", po::value<unsigned int>()->default_value(2), "specify how many bridges should be created")(
             "zbridges", po::value<double>(), "bridges height (Z-coordinates while engraving bridges, default to zsafe) ")(

--- a/segmentize.hpp
+++ b/segmentize.hpp
@@ -1,0 +1,36 @@
+#ifndef SEGMENTIZE_H
+#define SEGMENTIZE_H
+
+#include <vector>
+#include <map>
+
+#include "geometry.hpp"
+#include <boost/polygon/isotropy.hpp>
+#include <boost/polygon/segment_concept.hpp>
+#include <boost/polygon/segment_utils.hpp>
+
+typedef boost::polygon::point_data<coordinate_type> point_type_p;
+typedef boost::polygon::point_data<coordinate_type_fp> point_type_fp_p;
+typedef boost::polygon::segment_data<coordinate_type> segment_type_p;
+typedef boost::polygon::segment_data<coordinate_type_fp> segment_type_fp_p;
+
+/* Given a multi_linestring, return a new multiline_string where there
+ * are no segments that cross any other segments.  Nor are there any T
+ * shapes where the end of a linestring butts up against the center of
+ * another.
+ *
+ * Repeats are removed, as are segments that are identical but
+ * pointing in opposite directions.
+ */
+std::vector<segment_type_p> segmentize(const std::vector<segment_type_p>& all_segments) {
+  std::vector<segment_type_p> intersected_segments;
+  boost::polygon::intersect_segments(intersected_segments, all_segments.cbegin(), all_segments.cend());
+  // Sort the segments themselves.
+  std::sort(intersected_segments.begin(), intersected_segments.end());
+  auto last = std::unique(intersected_segments.begin(), intersected_segments.end());
+  intersected_segments.erase(last, intersected_segments.end());
+
+  return intersected_segments;
+}
+
+#endif //SEGMENTIZE_H

--- a/segmentize_tests.cpp
+++ b/segmentize_tests.cpp
@@ -1,0 +1,77 @@
+#define BOOST_TEST_MODULE segmentize tests
+#include <boost/test/included/unit_test.hpp>
+
+#include "segmentize.hpp"
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(segmentize_tests);
+
+struct PointLessThan {
+  bool operator()(const point_type& a, const point_type& b) const {
+    return std::tie(a.x(), a.y()) < std::tie(b.x(), b.y());
+  }
+};
+
+void print_result(const vector<segment_type_p>& result) {
+  for (const auto& s : result) {
+    printf("%ld %ld %ld %ld\n", s.low().x(), s.low().y(), s.high().x(), s.high().y());
+  }
+}
+
+
+BOOST_AUTO_TEST_CASE(abuts) {
+  vector<segment_type_p> ms;
+  ms.push_back(segment_type_p(point_type_p(0, 0), point_type_p(2, 2)));
+  ms.push_back(segment_type_p(point_type_p(1, 1), point_type_p(2, 0)));
+  const auto& result = segmentize(ms);
+  BOOST_CHECK(result.size() == 3);
+}
+
+BOOST_AUTO_TEST_CASE(x_shape) {
+  vector<segment_type_p> ms;
+  ms.push_back(segment_type_p(point_type_p(0, 10000), point_type_p(10000, 9000)));
+  ms.push_back(segment_type_p(point_type_p(10000, 10000), point_type_p(0, 0)));
+  const auto& result = segmentize(ms);
+  BOOST_CHECK(result.size() == 4);
+}
+
+BOOST_AUTO_TEST_CASE(plus_shape) {
+  vector<segment_type_p> ms;
+  ms.push_back(segment_type_p(point_type_p(1, 2), point_type_p(3, 2)));
+  ms.push_back(segment_type_p(point_type_p(2, 1), point_type_p(2, 3)));
+  const auto& result = segmentize(ms);
+  BOOST_CHECK(result.size() == 4);
+}
+
+BOOST_AUTO_TEST_CASE(touching_no_overlap) {
+  vector<segment_type_p> ms;
+  ms.push_back(segment_type_p(point_type_p(1, 20), point_type_p(40, 50)));
+  ms.push_back(segment_type_p(point_type_p(40, 50), point_type_p(80, 90)));
+  const auto& result = segmentize(ms);
+  BOOST_CHECK(result.size() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(parallel_with_overlap) {
+  vector<segment_type_p> ms;
+  ms.push_back(segment_type_p(point_type_p(10, 10), point_type_p(0, 0)));
+  ms.push_back(segment_type_p(point_type_p(9, 9), point_type_p(20, 20)));
+  ms.push_back(segment_type_p(point_type_p(9, 9), point_type_p(30, 30)));
+  const auto& result = segmentize(ms);
+  BOOST_CHECK(result.size() == 4);
+  //print_result(result);
+}
+
+BOOST_AUTO_TEST_CASE(sort_segments) {
+  vector<segment_type_p> ms;
+  ms.push_back(segment_type_p(point_type_p(10, 10), point_type_p(13, -4)));
+  ms.push_back(segment_type_p(point_type_p(13, -4), point_type_p(10, 10)));
+  ms.push_back(segment_type_p(point_type_p(13, -4), point_type_p(10, 10)));
+  ms.push_back(segment_type_p(point_type_p(10, 10), point_type_p(13, -4)));
+  ms.push_back(segment_type_p(point_type_p(10, 10), point_type_p(13, -4)));
+  const auto& result = segmentize(ms);
+  BOOST_CHECK(result.size() == 1);
+  //print_result(result);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/surface_vectorial.cpp
+++ b/surface_vectorial.cpp
@@ -207,7 +207,7 @@ vector<shared_ptr<icoords>> Surface_vectorial::scale_and_mirror_toolpath(
                                            point.y() / double(scale)));
             } else {
                 coords.push_back(make_pair(point.x() / double(scale),
-                                                    point.y() / double(scale)));
+                                           point.y() / double(scale)));
             }
         }
         result.push_back(make_shared<icoords>(coords));

--- a/surface_vectorial.cpp
+++ b/surface_vectorial.cpp
@@ -435,8 +435,7 @@ multi_linestring_type Surface_vectorial::eulerian_paths(const multi_linestring_t
     // Merge points that are very close to each other because it makes
     // us more likely to find intersections that was can use.
     multi_linestring_type merged_toolpaths(toolpaths);
-    printf("merging points\n");
-    printf("points merged: %ld\n", merge_near_points(merged_toolpaths));
+    merge_near_points(merged_toolpaths);
 
     // First we need to split all paths so that they don't cross.
     vector<segment_type_p> all_segments;
@@ -448,9 +447,7 @@ multi_linestring_type Surface_vectorial::eulerian_paths(const multi_linestring_t
                     point_type_p(toolpath[i  ].x(), toolpath[i  ].y())));
         }
     }
-    printf("converted to segments\n");
     vector<segment_type_p> split_segments = segmentize(all_segments);
-    printf("segmented\n");
 
     multi_linestring_type segments_as_linestrings;
     for (const auto& segment : split_segments) {
@@ -461,7 +458,6 @@ multi_linestring_type Surface_vectorial::eulerian_paths(const multi_linestring_t
         ls.push_back(point_type(segment.high().x(), segment.high().y()));
         segments_as_linestrings.push_back(ls);
     }
-    printf("sback to linestrings\n");
 
     // Make a minimal number of paths from those segments.
     struct PointLessThan {
@@ -475,7 +471,6 @@ multi_linestring_type Surface_vectorial::eulerian_paths(const multi_linestring_t
       linestring_type,
       multi_linestring_type,
       PointLessThan>(segments_as_linestrings);
-    printf("done\n");
 }
 
 

--- a/surface_vectorial.cpp
+++ b/surface_vectorial.cpp
@@ -127,7 +127,7 @@ vector<shared_ptr<icoords> > Surface_vectorial::get_toolpath(shared_ptr<RoutingM
         unique_ptr<vector<polygon_type> > polygons;
     
         polygons = offset_polygon(*vectorial_surface, integral_voronoi, toolpath, contentions,
-                                    grow, i, extra_passes + 1, mirror, mirror_axis);
+                                    grow, i, extra_passes + 1);
 
         debug_image.add(*polygons, 0.6, r, g, b);
         traced_debug_image.add(*polygons, 1, r, g, b);
@@ -218,7 +218,7 @@ vector<shared_ptr<icoords>> Surface_vectorial::scale_and_mirror_toolpath(
 unique_ptr<vector<polygon_type> > Surface_vectorial::offset_polygon(const multi_polygon_type& input,
                             const multi_polygon_type& voronoi, multi_linestring_type& toolpath,
                             bool& contentions, coordinate_type offset, size_t index,
-                            unsigned int steps, bool mirror, ivalue_t mirror_axis)
+                            unsigned int steps)
 {
     if (offset < 0)
         steps = 1;

--- a/surface_vectorial.hpp
+++ b/surface_vectorial.hpp
@@ -104,7 +104,7 @@ protected:
     unique_ptr<vector<polygon_type> > offset_polygon(const multi_polygon_type& input,
                             const multi_polygon_type& voronoi, multi_linestring_type& toolpath,
                             bool& contentions, coordinate_type offset, size_t index,
-                            unsigned int steps, bool mirror, ivalue_t mirror_axis);
+                            unsigned int steps);
 };
 
 class svg_writer

--- a/surface_vectorial.hpp
+++ b/surface_vectorial.hpp
@@ -92,8 +92,17 @@ protected:
     
     shared_ptr<Surface_vectorial> mask;
 
+    // Points that are very close to each other, probably because of a
+    // rounding error, are merged together to a single location.
+    static size_t merge_near_points(multi_linestring_type& mls);
+    // Returns a minimal number of toolpaths that include all the
+    // milling in the oroginal toolpaths.  Each path is traversed
+    // once.
+    multi_linestring_type eulerian_paths(const multi_linestring_type& toolpaths);
+    vector<shared_ptr<icoords>> scale_and_mirror_toolpath(
+        const multi_linestring_type& mls, bool mirror, ivalue_t mirror_axis);
     unique_ptr<vector<polygon_type> > offset_polygon(const multi_polygon_type& input,
-                            const multi_polygon_type& voronoi, vector< shared_ptr<icoords> >& toolpath,
+                            const multi_polygon_type& voronoi, multi_linestring_type& toolpath,
                             bool& contentions, coordinate_type offset, size_t index,
                             unsigned int steps, bool mirror, ivalue_t mirror_axis);
 };

--- a/tsp_solver.hpp
+++ b/tsp_solver.hpp
@@ -56,12 +56,27 @@ private:
         return get(line.first);
     }
 
+    static inline point_type get(const linestring_type& path)
+    {
+        // For finding the nearest neighbor, assume that the drilling
+        // will begin and end at the start point.
+        return path.front();
+    }
+
     // Return the Chebyshev distance, which is a good approximation
     // for the time it takes to do a rapid move on a CNC router.
     static inline double distance(icoordpair p0, icoordpair p1)
     {
         return std::max(std::abs(p0.first - p1.first),
                         std::abs(p0.second - p1.second));
+    }
+
+    // Return the Chebyshev distance, which is a good approximation
+    // for the time it takes to do a rapid move on a CNC router.
+    static inline coordinate_type distance(point_type p0, point_type p1)
+    {
+        return std::max(std::abs(p0.x() - p1.x()),
+                        std::abs(p0.y() - p1.x()));
     }
 public:
     // This function computes the optimised path of a
@@ -71,8 +86,8 @@ public:
     // In the case of shared_ptr<icoords> it interprets the vector<icoordpair> as closed paths, and it computes
     // the optimised path of the first point of each subpath. This can be used in the milling paths, where each
     // subpath is closed and we want to find the best subpath order
-    template <typename T>
-    static void nearest_neighbour(vector<T> &path, icoordpair startingPoint, double quantization_error)
+    template <typename T, typename point_t>
+    static void nearest_neighbour(vector<T> &path, point_t startingPoint, double quantization_error)
     {
         if (path.size() > 0)
         {
@@ -96,7 +111,7 @@ public:
             for (auto point = temp_path.begin(); next(point) != temp_path.end(); point++)
                 original_length += distance(get(*point), get(*next(point)));
 
-            icoordpair currentPoint = startingPoint;
+            point_t currentPoint = startingPoint;
             while (temp_path.size() > 1)
             {
 


### PR DESCRIPTION
This implements eulerian paths.  For non-voronoi milling this will have basically no effect.  For voronoi paths, it will prevent milling paths twice.  This cuts down the milling time by up to 50% (all paths except the outside boundary).

In the image below, the path on the left shows how the rapid moves and milling is much shorter than the one on the right.

![image](https://user-images.githubusercontent.com/109809/34935207-c11f94a8-f9e5-11e7-8653-f143181ee4c2.png)
