### PR TITLE
mirror-absolute / fixes #87

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -115,6 +115,7 @@ int main(int argc, char* argv[])
         isolator->tolerance = tolerance;
         isolator->explicit_tolerance = explicit_tolerance;
         isolator->mirror_absolute = vm["mirror-absolute"].as<bool>();
+        isolator->zero_start = vm["zero-start"].as<bool>();
     }
 
     shared_ptr<Cutter> cutter;
@@ -135,10 +136,11 @@ int main(int argc, char* argv[])
         cutter->do_steps = true;
         cutter->stepsize = vm["cut-infeed"].as<double>() * unit;
         cutter->optimise = vm["optimise"].as<bool>();
-        isolator->eulerian_paths = vm["eulerian-paths"].as<bool>();
+        cutter->eulerian_paths = vm["eulerian-paths"].as<bool>();
         cutter->tolerance = tolerance;
         cutter->explicit_tolerance = explicit_tolerance;
         cutter->mirror_absolute = vm["mirror-absolute"].as<bool>();
+        cutter->zero_start = vm["zero-start"].as<bool>();
         cutter->bridges_num = vm["bridgesnum"].as<unsigned int>();
         cutter->bridges_width = vm["bridges"].as<double>() * unit;
         if (vm.count("zbridges"))
@@ -159,6 +161,7 @@ int main(int argc, char* argv[])
         driller->tolerance = tolerance;
         driller->explicit_tolerance = explicit_tolerance;
         driller->mirror_absolute = vm["mirror-absolute"].as<bool>();
+        driller->zero_start = vm["zero-start"].as<bool>();
         driller->zchange = vm["zchange"].as<double>() * unit;
     }
 

--- a/mill.hpp
+++ b/mill.hpp
@@ -45,6 +45,7 @@ public:
     bool explicit_tolerance;
     bool backside;
     bool mirror_absolute;
+    bool zero_start;
 };
 
 /******************************************************************************/

--- a/surface_vectorial.cpp
+++ b/surface_vectorial.cpp
@@ -111,9 +111,17 @@ vector<shared_ptr<icoords> > Surface_vectorial::get_toolpath(shared_ptr<RoutingM
     srand(1);
     debug_image.add(integral_voronoi, 0.3, false);
 
-    const coordinate_type mirror_axis = mill->mirror_absolute ?
-        bounding_box.min_corner().x() :
-        ((bounding_box.min_corner().x() + bounding_box.max_corner().x()) / 2);
+    coordinate_type mirror_axis = 0;
+    if (mill->mirror_absolute && mill->zero_start) {
+        mirror_axis = bounding_box.min_corner().x();
+    }
+    if (mill->mirror_absolute && !mill->zero_start) {
+        mirror_axis = (coordinate_type)0;
+    }
+    if (!mill->mirror_absolute) {
+        mirror_axis = ((bounding_box.min_corner().x() + bounding_box.max_corner().x()) / 2);
+    }
+
     bool contentions = false;
 
     srand(1);

--- a/surface_vectorial.cpp
+++ b/surface_vectorial.cpp
@@ -111,16 +111,10 @@ vector<shared_ptr<icoords> > Surface_vectorial::get_toolpath(shared_ptr<RoutingM
     srand(1);
     debug_image.add(integral_voronoi, 0.3, false);
 
-    coordinate_type mirror_axis = 0;
-    if (mill->mirror_absolute && mill->zero_start) {
-        mirror_axis = bounding_box.min_corner().x();
-    }
-    if (mill->mirror_absolute && !mill->zero_start) {
-        mirror_axis = (coordinate_type)0;
-    }
-    if (!mill->mirror_absolute) {
-        mirror_axis = ((bounding_box.min_corner().x() + bounding_box.max_corner().x()) / 2);
-    }
+    const coordinate_type mirror_axis = 
+        (mill->mirror_absolute && mill->zero_start) ?  bounding_box.min_corner().x() :
+        (!mill->mirror_absolute)                    ? ((bounding_box.min_corner().x() + bounding_box.max_corner().x()) / 2) :
+        0;
 
     bool contentions = false;
 


### PR DESCRIPTION
this changes the mirror axis if mirror-absolute and zero-start are both
active. The previous behavior was inconsitent with the manual. The new
behavior allows the user to zero a back layer on the gerber zero,
because it is consistent on front and back layer. This fix changes only
vectorial behavior.