### PR TITLE
adds a note about autoconf et al for building on osx with brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ You can build the latest pcb2gcode version with [Homebrew](http://brew.sh). If H
 
      $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
      
+You might need some build tools that typically is not present:
+
+     $ brew install autoconf automake libtool
+
 Then you can download and build the git version with
      
      $ brew install --HEAD pcb2gcode

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ You can build the latest pcb2gcode version with [Homebrew](http://brew.sh). If H
 
      $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
      
-You might need some build tools that typically is not present:
+You might need some build tools that typically are not present:
 
      $ brew install autoconf automake libtool
 


### PR DESCRIPTION
I'm not bootstrapped for building c/c++ with homebrew and I needed these extra build deps.