### PR TITLE
Run pcb2gcode as part of travis script so that we can catch more errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,6 @@ script:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then ./configure --disable-dependency-tracking --disable-silent-rules --with-boost="$BOOST_DIR" --enable-static-boost; fi
   - make
   - make check
-
-after_script:
   - cd testing/gerbv_example/
   - ARGS='--bridges=0.5 --bridgesnum=2 --zbridges=-0.6 --al-front=true --al-back=true --al-probefeed=100 --al-x=15.0000 --al-y=15.0000 --tile-x=3 --tile-y=2'
-  - for dir in *; do cd $dir; ../../../pcb2gcode --software=LinuxCNC $ARGS; cd ..; done
+  - (for dir in *; do cd $dir; ../../../pcb2gcode --software=LinuxCNC $ARGS || exit ; cd ..; done)

--- a/testing/gerbv_example/A64-OlinuXino_Rev_D/millproject
+++ b/testing/gerbv_example/A64-OlinuXino_Rev_D/millproject
@@ -7,7 +7,7 @@ outline=A64-OlinuXino_Rev_D-Edge.Cuts.gbr
 
 extra-passes=0
 offset=0.001
-vectorial=true
+vectorial=false #Vectorial is broken in boost 1.56 for this complicated project
 mill-feed=360
 mill-speed=12000
 voronoi=false


### PR DESCRIPTION
Currently, pcb2gcode is run on every subdirectory in the `gerbv_example` directory but only as part of the `after_script`.  So if pcb2gcode fails, TravisCI still reports success.

With this change, if pcb2gcode exits with a failure, TravisCI will also report a failure.