### PR TITLE
Have travis wget boost libs from github instead of sourcefourge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update && brew reinstall -s libtool && brew outdated boost || brew upgrade boost && brew install gtkmm gerbv; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget -qO- "https://sourceforge.net/projects/pcb2gcode/files/pcb2gcode/boost/boost_${BOOST}_amd64.tar.xz/download" | tar xJ && export BOOST_DIR="$PWD/boost"; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget -qO- "https://github.com/eyal0/pcb2gcode/releases/download/1.3.3/boost_${BOOST}_amd64.tar.xz" | tar xJ && export BOOST_DIR="$PWD/boost"; fi
 
 install:
   - export CXX=$COMPILER


### PR DESCRIPTION
Sourceforge downloads sometimes fail and recently had an outage for a few hours.  github seems more reliable for downloading.