### PR TITLE
Cleanup the whitespace, which wasn't consistent with how boost does it

### DIFF
--- a/options.cpp
+++ b/options.cpp
@@ -207,88 +207,87 @@ void options::parse_files()
 options::options()
          : cli_options("command line only options"), cfg_options("generic options (CLI and config files)") {
 
-   cli_options.add_options()(
-            "noconfigfile", po::value<bool>()->default_value(false)->implicit_value(true), "ignore any configuration file")(
-            "help,?", "produce help message")(
-            "version", "show the current software version");
-   cfg_options.add_options()(
-            "front", po::value<string>(),"front side RS274-X .gbr")(
-            "back", po::value<string>(), "back side RS274-X .gbr")(
-            "outline", po::value<string>(), "pcb outline polygon RS274-X .gbr")(
-            "drill", po::value<string>(), "Excellon drill file")(
-            "svg", po::value<string>(), "[DEPRECATED] use --vectorial, SVGs will be generated automatically; this option has no effect")(
-            "zwork", po::value<Length>(), "milling depth in inches (Z-coordinate while engraving)")(
-            "zsafe", po::value<double>(), "safety height (Z-coordinate during rapid moves)")(
-            "offset", po::value<Length>()->default_value(Length(0)), "distance between the PCB traces and the end mill path in inches; usually half the isolation width")(
-            "voronoi", po::value<bool>()->default_value(false)->implicit_value(true), "generate voronoi regions (requires --vectorial)")(
-            "spinup-time", po::value<double>()->default_value(1), "time required to the spindle to reach the correct speed")(
-            "spindown-time", po::value<double>(), "time required to the spindle to return to 0 rpm")(
-            "mill-feed", po::value<Velocity>(), "feed while isolating in [i/m] or [mm/m]")(
-            "mill-vertfeed", po::value<double>(), "vertical feed while isolating in [i/m] or [mm/m]")(
-            "mill-speed", po::value<Frequency>(), "spindle rpm when milling")(
-            "milldrill", po::value<bool>()->default_value(false)->implicit_value(true), "drill using the mill head")(
-            "milldrill-diameter", po::value<double>(), "diameter of the end mill used for drilling with --milldrill")(
-            "nog81", po::value<bool>()->default_value(false)->implicit_value(true), "replace G81 with G0+G1")(
-            "nog91-1", po::value<bool>()->default_value(false)->implicit_value(true), "do not explicitly set G91.1 in drill headers")(
-            "extra-passes", po::value<int>()->default_value(0), "specify the the number of extra isolation passes, increasing the isolation width half the tool diameter with each pass")(
-            "fill-outline", po::value<bool>()->default_value(true)->implicit_value(true), "accept a contour instead of a polygon as outline (enabled by default)")(
-            "outline-width", po::value<double>(), "width of the outline, used only when vectorial is disabled")(
-            "cutter-diameter", po::value<double>(), "diameter of the end mill used for cutting out the PCB")(
-            "zcut", po::value<double>(), "PCB cutting depth in inches")(
-            "cut-feed", po::value<double>(), "PCB cutting feed in [i/m] or [mm/m]")(
-            "cut-vertfeed", po::value<double>(), "PCB vertical cutting feed in [i/m] or [mm/m]")(
-            "cut-speed", po::value<int>(), "spindle rpm when cutting")(
-            "cut-infeed", po::value<double>(), "maximum cutting depth; PCB may be cut in multiple passes")(
-            "cut-front", po::value<bool>()->implicit_value(true), "[DEPRECATED, use cut-side instead] cut from front side. ")(
-            "cut-side", po::value<string>()->default_value("auto"), "cut side; valid choices are front, back or auto (default)")(
-            "zdrill", po::value<double>(), "drill depth")(
-            "zchange", po::value<double>(), "tool changing height")(
-            "zchange-absolute", po::value<bool>()->default_value(false)->implicit_value(true), "use zchange as a machine coordinates height (G53)")(
-            "drill-feed", po::value<double>(), "drill feed in [i/m] or [mm/m]")(
-            "drill-speed", po::value<int>(), "spindle rpm when drilling")(
-            "drill-front", po::value<bool>()->implicit_value(true), "[DEPRECATED, use drill-side instead] drill through the front side of board")(
-            "drill-side", po::value<string>()->default_value("auto"), "drill side; valid choices are front, back or auto (default)")(
-            "onedrill", po::value<bool>()->default_value(false)->implicit_value(true), "use only one drill bit size")(
-            "metric", po::value<bool>()->default_value(false)->implicit_value(true), "use metric units for parameters. does not affect gcode output")(
-            "metricoutput", po::value<bool>()->default_value(false)->implicit_value(true), "use metric units for output")(
-            "optimise", po::value<bool>()->default_value(true)->implicit_value(true), "Reduce output file size by up to 40% while accepting a little loss of precision (enabled by default).")(
-            "eulerian-paths", po::value<bool>()->default_value(true)->implicit_value(true), "Don't mill the same path twice if milling loops overlap.  This can save up to 50% of milling time.  Enabled by default.")(
-            "bridges", po::value<double>()->default_value(0), "add bridges with the given width to the outline cut")(
-            "bridgesnum", po::value<unsigned int>()->default_value(2), "specify how many bridges should be created")(
-            "zbridges", po::value<double>(), "bridges height (Z-coordinates while engraving bridges, default to zsafe) ")(
-            "tile-x", po::value<int>()->default_value(1), "number of tiling columns. Default value is 1")(
-            "tile-y", po::value<int>()->default_value(1), "number of tiling rows. Default value is 1")(
-            "al-front", po::value<bool>()->default_value(false)->implicit_value(true),
-            "enable the z autoleveller for the front layer")(
-            "al-back", po::value<bool>()->default_value(false)->implicit_value(true),
-            "enable the z autoleveller for the back layer")(
-            "software", po::value<string>(), "choose the destination software (useful only with the autoleveller). Supported programs are linuxcnc, mach3, mach4 and custom")(
-            "al-x", po::value<double>(), "width of the x probes")(
-            "al-y", po::value<double>(), "width of the y probes")(
-            "al-probefeed", po::value<double>(), "speed during the probing")(
-            "al-probe-on", po::value<string>()->default_value("(MSG, Attach the probe tool)@M0 ( Temporary machine stop. )"), "execute this commands to enable the probe tool (default is M0)")(
-            "al-probe-off", po::value<string>()->default_value("(MSG, Detach the probe tool)@M0 ( Temporary machine stop. )"), "execute this commands to disable the probe tool (default is M0)")(
-            "al-probecode", po::value<string>()->default_value("G31"), "custom probe code (default is G31)")(
-            "al-probevar", po::value<unsigned int>()->default_value(2002), "number of the variable where the result of the probing is saved (default is 2002)")(
-            "al-setzzero", po::value<string>()->default_value("G92 Z0"), "gcode for setting the actual position as zero (default is G92 Z0)")(
-            "dpi", po::value<int>()->default_value(1000), "virtual photoplot resolution")(
-            "vectorial", po::value<bool>()->default_value(false)->implicit_value(true), "EXPERIMENTAL!! Enable the experimental vectorial core")(
-            "zero-start", po::value<bool>()->default_value(false)->implicit_value(true), "set the starting point of the project at (0,0)")(
-            "g64", po::value<double>(), "[DEPRECATED, use tolerance instead] maximum deviation from toolpath, overrides internal calculation")(
-            "tolerance", po::value<double>(), "maximum toolpath tolerance")(
-            "nog64", po::value<bool>()->default_value(false)->implicit_value(true), "do not set an explicit g64")(
-            "mirror-absolute", po::value<bool>()->default_value(false)->implicit_value(true), "mirror back side along absolute zero instead of board center")(
-            "tsp-2opt", po::value<bool>()->default_value(true)->implicit_value(true), "use TSP 2OPT to find a faster toolpath (but slows down gcode generation)")(
-            "output-dir", po::value<string>()->default_value(""), "output directory")(
-            "basename", po::value<string>(), "prefix for default output file names")(
-            "front-output", po::value<string>()->default_value("front.ngc"), "output file for front layer")(
-            "back-output", po::value<string>()->default_value("back.ngc"), "output file for back layer")(
-            "outline-output", po::value<string>()->default_value("outline.ngc"), "output file for outline")(
-            "drill-output", po::value<string>()->default_value("drill.ngc"), "output file for drilling")(
-            "preamble-text", po::value<string>(), "preamble text file, inserted at the very beginning as a comment.")(
-            "preamble", po::value<string>(), "gcode preamble file, inserted at the very beginning.")(
-            "postamble", po::value<string>(), "gcode postamble file, inserted before M9 and M2.")(
-            "no-export", po::value<bool>()->default_value(false)->implicit_value(true), "skip the exporting process");
+   cli_options.add_options()
+       ("noconfigfile", po::value<bool>()->default_value(false)->implicit_value(true), "ignore any configuration file")
+       ("help,?", "produce help message")
+       ("version", "show the current software version");
+   cfg_options.add_options()
+       ("front", po::value<string>(),"front side RS274-X .gbr")
+       ("back", po::value<string>(), "back side RS274-X .gbr")
+       ("outline", po::value<string>(), "pcb outline polygon RS274-X .gbr")
+       ("drill", po::value<string>(), "Excellon drill file")
+       ("svg", po::value<string>(), "[DEPRECATED] use --vectorial, SVGs will be generated automatically; this option has no effect")
+       ("zwork", po::value<Length>(), "milling depth in inches (Z-coordinate while engraving)")
+       ("zsafe", po::value<double>(), "safety height (Z-coordinate during rapid moves)")
+       ("offset", po::value<Length>()->default_value(Length(0)), "distance between the PCB traces and the end mill path in inches; usually half the isolation width")
+       ("voronoi", po::value<bool>()->default_value(false)->implicit_value(true), "generate voronoi regions (requires --vectorial)")
+       ("spinup-time", po::value<double>()->default_value(1), "time required to the spindle to reach the correct speed")
+       ("spindown-time", po::value<double>(), "time required to the spindle to return to 0 rpm")
+       ("mill-feed", po::value<Velocity>(), "feed while isolating in [i/m] or [mm/m]")
+       ("mill-vertfeed", po::value<double>(), "vertical feed while isolating in [i/m] or [mm/m]")
+       ("mill-speed", po::value<Frequency>(), "spindle rpm when milling")
+       ("milldrill", po::value<bool>()->default_value(false)->implicit_value(true), "drill using the mill head")
+       ("milldrill-diameter", po::value<double>(), "diameter of the end mill used for drilling with --milldrill")
+       ("nog81", po::value<bool>()->default_value(false)->implicit_value(true), "replace G81 with G0+G1")
+       ("nog91-1", po::value<bool>()->default_value(false)->implicit_value(true), "do not explicitly set G91.1 in drill headers")
+       ("extra-passes", po::value<int>()->default_value(0), "specify the the number of extra isolation passes, increasing the isolation width half the tool diameter with each pass")
+       ("fill-outline", po::value<bool>()->default_value(true)->implicit_value(true), "accept a contour instead of a polygon as outline (enabled by default)")
+       ("outline-width", po::value<double>(), "width of the outline, used only when vectorial is disabled")
+       ("cutter-diameter", po::value<double>(), "diameter of the end mill used for cutting out the PCB")
+       ("zcut", po::value<double>(), "PCB cutting depth in inches")
+       ("cut-feed", po::value<double>(), "PCB cutting feed in [i/m] or [mm/m]")
+       ("cut-vertfeed", po::value<double>(), "PCB vertical cutting feed in [i/m] or [mm/m]")
+       ("cut-speed", po::value<int>(), "spindle rpm when cutting")
+       ("cut-infeed", po::value<double>(), "maximum cutting depth; PCB may be cut in multiple passes")
+       ("cut-front", po::value<bool>()->implicit_value(true), "[DEPRECATED, use cut-side instead] cut from front side. ")
+       ("cut-side", po::value<string>()->default_value("auto"), "cut side; valid choices are front, back or auto (default)")
+       ("zdrill", po::value<double>(), "drill depth")
+       ("zchange", po::value<double>(), "tool changing height")
+       ("zchange-absolute", po::value<bool>()->default_value(false)->implicit_value(true), "use zchange as a machine coordinates height (G53)")
+       ("drill-feed", po::value<double>(), "drill feed in [i/m] or [mm/m]")
+       ("drill-speed", po::value<int>(), "spindle rpm when drilling")
+       ("drill-front", po::value<bool>()->implicit_value(true), "[DEPRECATED, use drill-side instead] drill through the front side of board")
+       ("drill-side", po::value<string>()->default_value("auto"), "drill side; valid choices are front, back or auto (default)")
+       ("onedrill", po::value<bool>()->default_value(false)->implicit_value(true), "use only one drill bit size")
+       ("metric", po::value<bool>()->default_value(false)->implicit_value(true), "use metric units for parameters. does not affect gcode output")
+       ("metricoutput", po::value<bool>()->default_value(false)->implicit_value(true), "use metric units for output")
+       ("optimise", po::value<bool>()->default_value(true)->implicit_value(true), "Reduce output file size by up to 40% while accepting a little loss of precision (enabled by default).")
+       ("eulerian-paths", po::value<bool>()->default_value(true)->implicit_value(true), "Don't mill the same path twice if milling loops overlap.  This can save up to 50% of milling time.  Enabled by default.")
+       ("bridges", po::value<double>()->default_value(0), "add bridges with the given width to the outline cut")
+       ("bridgesnum", po::value<unsigned int>()->default_value(2), "specify how many bridges should be created")
+       ("zbridges", po::value<double>(), "bridges height (Z-coordinates while engraving bridges, default to zsafe) ")
+       ("tile-x", po::value<int>()->default_value(1), "number of tiling columns. Default value is 1")
+       ("tile-y", po::value<int>()->default_value(1), "number of tiling rows. Default value is 1")
+       ("al-front", po::value<bool>()->default_value(false)->implicit_value(true), "enable the z autoleveller for the front layer")
+       ("al-back", po::value<bool>()->default_value(false)->implicit_value(true),
+            "enable the z autoleveller for the back layer")
+       ("software", po::value<string>(), "choose the destination software (useful only with the autoleveller). Supported programs are linuxcnc, mach3, mach4 and custom")
+       ("al-x", po::value<double>(), "width of the x probes")
+       ("al-y", po::value<double>(), "width of the y probes")
+       ("al-probefeed", po::value<double>(), "speed during the probing")
+       ("al-probe-on", po::value<string>()->default_value("(MSG, Attach the probe tool)@M0 ( Temporary machine stop. )"), "execute this commands to enable the probe tool (default is M0)")
+       ("al-probe-off", po::value<string>()->default_value("(MSG, Detach the probe tool)@M0 ( Temporary machine stop. )"), "execute this commands to disable the probe tool (default is M0)")
+       ("al-probecode", po::value<string>()->default_value("G31"), "custom probe code (default is G31)")
+       ("al-probevar", po::value<unsigned int>()->default_value(2002), "number of the variable where the result of the probing is saved (default is 2002)")
+       ("al-setzzero", po::value<string>()->default_value("G92 Z0"), "gcode for setting the actual position as zero (default is G92 Z0)")
+       ("dpi", po::value<int>()->default_value(1000), "virtual photoplot resolution")
+       ("vectorial", po::value<bool>()->default_value(false)->implicit_value(true), "EXPERIMENTAL!! Enable the experimental vectorial core")
+       ("zero-start", po::value<bool>()->default_value(false)->implicit_value(true), "set the starting point of the project at (0,0)")
+       ("g64", po::value<double>(), "[DEPRECATED, use tolerance instead] maximum deviation from toolpath, overrides internal calculation")
+       ("tolerance", po::value<double>(), "maximum toolpath tolerance")
+       ("nog64", po::value<bool>()->default_value(false)->implicit_value(true), "do not set an explicit g64")
+       ("mirror-absolute", po::value<bool>()->default_value(false)->implicit_value(true), "mirror back side along absolute zero instead of board center")
+       ("tsp-2opt", po::value<bool>()->default_value(true)->implicit_value(true), "use TSP 2OPT to find a faster toolpath (but slows down gcode generation)")
+       ("output-dir", po::value<string>()->default_value(""), "output directory")
+       ("basename", po::value<string>(), "prefix for default output file names")
+       ("front-output", po::value<string>()->default_value("front.ngc"), "output file for front layer")
+       ("back-output", po::value<string>()->default_value("back.ngc"), "output file for back layer")
+       ("outline-output", po::value<string>()->default_value("outline.ngc"), "output file for outline")
+       ("drill-output", po::value<string>()->default_value("drill.ngc"), "output file for drilling")
+       ("preamble-text", po::value<string>(), "preamble text file, inserted at the very beginning as a comment.")
+       ("preamble", po::value<string>(), "gcode preamble file, inserted at the very beginning.")
+       ("postamble", po::value<string>(), "gcode postamble file, inserted before M9 and M2.")
+       ("no-export", po::value<bool>()->default_value(false)->implicit_value(true), "skip the exporting process");
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Cleanup the whitespace, which wasn't consistent with how boost does it in their examples