### PR TITLE
Call bg::simplify only on boost geometries and not on vectors of pairs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ export LC_NUMERIC="POSIX"
 # Checks for libraries.
 # Don't use Boost >= 1.67 because it has broken geometry.
 # https://svn.boost.org/trac10/ticket/13645
-BOOST_REQUIRE([BOOST_VERSION >= 105600 && BOOST_VERSION < 106700])
+BOOST_REQUIRE([BOOST_VERSION >= 105600])
 BOOST_PROGRAM_OPTIONS
 BOOST_GEOMETRY
 BOOST_STRING_ALGO

--- a/surface_vectorial.hpp
+++ b/surface_vectorial.hpp
@@ -105,8 +105,6 @@ protected:
   // is larger than the half the thickness of the thermal relief.
   // Returns the number of thermal reliefs found and filled.
   size_t preserve_thermal_reliefs(multi_polygon_type_fp& milling_surface, const coordinate_type_fp& tollerance);
-  vector<shared_ptr<icoords>> scale_and_mirror_toolpath(
-      const multi_linestring_type_fp& mls, bool mirror);
   vector<multi_polygon_type_fp> offset_polygon(
       const polygon_type_fp& input,
       const polygon_type_fp& voronoi,

--- a/testing/gerbv_example/KNoT-Gateway Mini Starter Board/expected/back.ngc
+++ b/testing/gerbv_example/KNoT-Gateway Mini Starter Board/expected/back.ngc
@@ -1995,8 +1995,6 @@ G01 Z-0.10000
 G04 P0 ( dwell for no time -- G64 should not smooth over this point )
 G01 F360.00000
 G01 X-34.70592 Y0.05080
-G01 X-34.58670 Y0.17656
-G01 X-34.43387 Y0.33134
 G01 X-34.29107 Y0.47445
 G04 P0 ( dwell for no time -- G64 should not smooth over this point )
 G00 Z10.00000 ( retract )

--- a/testing/gerbv_example/KNoT_Thing_Starter_Board/expected/back.ngc
+++ b/testing/gerbv_example/KNoT_Thing_Starter_Board/expected/back.ngc
@@ -983,8 +983,6 @@ G01 Z-0.10000
 G04 P0 ( dwell for no time -- G64 should not smooth over this point )
 G01 F360.00000
 G01 X-33.24885 Y6.15188
-G01 X-33.28228 Y6.28673
-G01 X-33.29635 Y6.34429
 G01 X-33.32549 Y6.46504
 G04 P0 ( dwell for no time -- G64 should not smooth over this point )
 G00 Z10.00000 ( retract )

--- a/testing/gerbv_example/multivibrator-clockwise/expected/back.ngc
+++ b/testing/gerbv_example/multivibrator-clockwise/expected/back.ngc
@@ -2590,7 +2590,6 @@ G01 Z-0.04000
 G04 P0 ( dwell for no time -- G64 should not smooth over this point )
 G01 F360.00000
 G01 X-4.51578 Y-2.81639
-G01 X-4.51578 Y-2.81639
 G01 X-4.51941 Y-2.81503
 G01 X-4.51578 Y-2.81639
 G04 P0 ( dwell for no time -- G64 should not smooth over this point )


### PR DESCRIPTION
This fixes https://github.com/pcb2gcode/pcb2gcode/issues/192