### PR TITLE
Use Cairo surfaces and png instead of the grid and xpm outputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ script:
   - ls | ../../parallel-*/src/parallel -j 2 --halt soon,fail=1 "pushd {}; echo 'Running on {}' ; ../../../pcb2gcode ${VECTORIAL} || exit ; popd" || travis_terminate 1
   - popd || travis_terminate 1
   - lcov --directory . -z || true #Ignore errors
-  - VERBOSE=1 make -j 2 check || travis_terminate 1
+  - VERBOSE=1 SKIP_GERBERIMPORTER_TESTS_PNG=1 make -j 2 check || travis_terminate 1
   - if [ "${ENABLE_CODE_COVERAGE}" ]; then ./integration_tests.py; fi || travis_terminate 1
 
 after_success:

--- a/gerberimporter.cpp
+++ b/gerberimporter.cpp
@@ -76,7 +76,8 @@ gdouble GerberImporter::get_max_y() const {
   return project->file[0]->image->info->max_y;
 }
 
-void GerberImporter::render(Cairo::RefPtr<Cairo::ImageSurface> surface, const guint dpi, const double min_x, const double min_y) const {
+void GerberImporter::render(Cairo::RefPtr<Cairo::ImageSurface> surface, const guint dpi, const double min_x, const double min_y,
+                            GdkColor color) const {
   gerbv_render_info_t render_info;
 
   render_info.scaleFactorX = dpi;
@@ -87,13 +88,10 @@ void GerberImporter::render(Cairo::RefPtr<Cairo::ImageSurface> surface, const gu
   render_info.displayHeight = surface->get_height();
   render_info.renderType = GERBV_RENDER_TYPE_CAIRO_NORMAL;
 
-  GdkColor color_saturated_white = { 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF };
-  project->file[0]->color = color_saturated_white;
+  project->file[0]->color = color;
 
-  cairo_t* cr = cairo_create(surface->cobj());
-  gerbv_render_layer_to_cairo_target(cr, project->file[0], &render_info);
-
-  cairo_destroy(cr);
+  Cairo::RefPtr<Cairo::Context> cr = Cairo::Context::create(surface);
+  gerbv_render_layer_to_cairo_target(cr->cobj(), project->file[0], &render_info);
 
   /// @todo check wheter importing was successful
 }

--- a/gerberimporter.cpp
+++ b/gerberimporter.cpp
@@ -77,7 +77,7 @@ gdouble GerberImporter::get_max_y() const {
 }
 
 void GerberImporter::render(Cairo::RefPtr<Cairo::ImageSurface> surface, const guint dpi, const double min_x, const double min_y,
-                            GdkColor color) const {
+                            const GdkColor& color) const {
   gerbv_render_info_t render_info;
 
   render_info.scaleFactorX = dpi;

--- a/gerberimporter.hpp
+++ b/gerberimporter.hpp
@@ -60,9 +60,10 @@ public:
     virtual gdouble get_min_y() const;
     virtual gdouble get_max_y() const;
 
+  //static constexpr GdkColor SATURATED_WHITE = { 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF };
     virtual void render(Cairo::RefPtr<Cairo::ImageSurface> surface,
                         const guint dpi, const double min_x,
-                        const double min_y) const;
+                        const double min_y, GdkColor color = { 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF }) const;
 
     virtual multi_polygon_type_fp render(bool fill_closed_lines, unsigned int points_per_circle = 30) const;
   virtual inline unsigned int vectorial_scale() const {

--- a/gerberimporter.hpp
+++ b/gerberimporter.hpp
@@ -62,7 +62,7 @@ public:
 
     virtual void render(Cairo::RefPtr<Cairo::ImageSurface> surface,
                         const guint dpi, const double min_x,
-                        const double min_y, GdkColor color = { 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF }) const;
+                        const double min_y, const GdkColor& color = { 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF }) const;
 
     virtual multi_polygon_type_fp render(bool fill_closed_lines, unsigned int points_per_circle = 30) const;
   virtual inline unsigned int vectorial_scale() const {

--- a/gerberimporter.hpp
+++ b/gerberimporter.hpp
@@ -60,7 +60,6 @@ public:
     virtual gdouble get_min_y() const;
     virtual gdouble get_max_y() const;
 
-  //static constexpr GdkColor SATURATED_WHITE = { 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF };
     virtual void render(Cairo::RefPtr<Cairo::ImageSurface> surface,
                         const guint dpi, const double min_x,
                         const double min_y, GdkColor color = { 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF }) const;

--- a/gerberimporter_tests.cpp
+++ b/gerberimporter_tests.cpp
@@ -179,6 +179,11 @@ void test_one(const string& gerber_file, double max_error_rate) {
             << std::endl;
   std::cout.precision(old_precision);
   BOOST_CHECK_LE(error_rate, max_error_rate);
+  const char *skip_png = std::getenv("SKIP_GERBERIMPORTER_TESTS_PNG");
+  if (skip_png != nullptr) {
+    std::cout << "Skipping png generation because SKIP_GERBERIMPORTER_TESTS_PNG is set in environment." << std::endl;
+    return;
+  }
   cairo_surface->write_to_png(str(boost::format("%s.png") % gerber_file).c_str());
 }
 
@@ -222,6 +227,11 @@ void test_visual(const string& gerber_file, double min_set_ratio, double max_set
   std::cout.precision(old_precision);
   BOOST_CHECK_GE(marked_ratio, min_set_ratio);
   BOOST_CHECK_LE(marked_ratio, max_set_ratio);
+  const char *skip_png = std::getenv("SKIP_GERBERIMPORTER_TESTS_PNG");
+  if (skip_png != nullptr) {
+    std::cout << "Skipping png generation because SKIP_GERBERIMPORTER_TESTS_PNG is set in environment." << std::endl;
+    return;
+  }
   cairo_surface->write_to_png(str(boost::format("%s.png") % gerber_file).c_str());
 }
 

--- a/gerberimporter_tests.cpp
+++ b/gerberimporter_tests.cpp
@@ -80,7 +80,7 @@ string render_svg(const multi_polygon_type_fp& polys, double min_x, double min_y
                                       svg_height * dpi / 1000000,
                                       svg_dimensions);
     svg.add(polys); // This is needed for the next line to work, not sure why.
-    svg.map(polys, str(boost::format("opacity:%1%;fill:rgb(%2%,%3%,%4%);")
+    svg.map(polys, str(boost::format("fill-opacity:%1%;fill:rgb(%2%,%3%,%4%);")
                        % (((NEW_COLOR >> 24) & 0xff ) / double(0xff))
                        % ((NEW_COLOR >> 16) & 0xff)
                        % ((NEW_COLOR >>  8) & 0xff)

--- a/gerberimporter_tests.cpp
+++ b/gerberimporter_tests.cpp
@@ -49,7 +49,7 @@ Cairo::RefPtr<Cairo::ImageSurface> create_cairo_surface(double width, double hei
 // Given a gerber file, return a pixmap that is a rasterized version of that
 // gerber.  Uses gerbv's built-in utils.
 void bitmap_from_gerber(const GerberImporter& g, double min_x, double min_y, double width, double height,
-                                                      Cairo::RefPtr<Cairo::ImageSurface> cairo_surface) {
+                        Cairo::RefPtr<Cairo::ImageSurface> cairo_surface) {
   //Render
   GdkColor blue = {0,
                    ((OLD_COLOR >> 16) & 0xff) * 0x101,

--- a/importer.hpp
+++ b/importer.hpp
@@ -59,7 +59,7 @@ class RasterLayerImporter : virtual public LayerImporter
 {
 public:
     virtual void render(Cairo::RefPtr<Cairo::ImageSurface> surface,
-                        const guint dpi, const double xoff, const double yoff) const = 0;
+                        const guint dpi, const double xoff, const double yoff, GdkColor color) const = 0;
 
 };
 

--- a/importer.hpp
+++ b/importer.hpp
@@ -60,7 +60,7 @@ class RasterLayerImporter : virtual public LayerImporter
 public:
     virtual void render(Cairo::RefPtr<Cairo::ImageSurface> surface,
                         const guint dpi, const double xoff, const double yoff,
-                        GdkColor color =  { 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF }) const = 0;
+                        const GdkColor& color =  { 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF }) const = 0;
 
 };
 

--- a/importer.hpp
+++ b/importer.hpp
@@ -59,7 +59,8 @@ class RasterLayerImporter : virtual public LayerImporter
 {
 public:
     virtual void render(Cairo::RefPtr<Cairo::ImageSurface> surface,
-                        const guint dpi, const double xoff, const double yoff, GdkColor color) const = 0;
+                        const guint dpi, const double xoff, const double yoff,
+                        GdkColor color =  { 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF }) const = 0;
 
 };
 


### PR DESCRIPTION
This makes the test run much faster.