### PR TITLE
Pin gerbv to an older verison

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ install:
       export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PWD/.local/lib/pkgconfig &&
       git clone git://git.geda-project.org/gerbv.git &&
       pushd gerbv &&
+      git chdckout 8ae933d &&
       sh autogen.sh &&
       CFLAGS=-std=gnu99 ./configure --disable-update-desktop-database --prefix=$PWD/../.local &&
       make -j 2 &&


### PR DESCRIPTION
Because the latest gerbv requires gettext 0.19 or newer and we don't have that for TravisCI