### PR TITLE
Remove "using" from many header files

### DIFF
--- a/autoleveller.cpp
+++ b/autoleveller.cpp
@@ -26,7 +26,13 @@
 #include <boost/geometry/algorithms/distance.hpp>
 
 #include <boost/format.hpp>
+#include <memory>
+#include <vector>
 using boost::format;
+using std::shared_ptr;
+using std::vector;
+using std::endl;
+using std::to_string;
 
 #include "units.hpp"
 

--- a/autoleveller.cpp
+++ b/autoleveller.cpp
@@ -33,6 +33,7 @@ using std::shared_ptr;
 using std::vector;
 using std::endl;
 using std::to_string;
+using std::string;
 
 #include "units.hpp"
 

--- a/autoleveller.hpp
+++ b/autoleveller.hpp
@@ -62,11 +62,11 @@ public:
     // required number of points between the previous and the current point and it interpolates them too.
     // This function adds a new chain point. Always call setLastChainPoint before starting a new chain
     // (call it also for the 1st chain)
-    string addChainPoint ( icoordpair point );
+    std::string addChainPoint ( icoordpair point );
 
     // g01Corrected interpolates only one point (without adding it to the chain), and it prints a G01 to that
     // position
-    string g01Corrected ( icoordpair point );
+    std::string g01Corrected ( icoordpair point );
 
     // Set lastPoint as the last chain point. You can use this function when you want to start a new chain
     inline void setLastChainPoint ( icoordpair lastPoint )
@@ -100,18 +100,18 @@ public:
     const double input_unitconv;
     const double output_unitconv;
     const double cfactor;
-    const string probeCodeCustom;
-    const string zProbeResultVarCustom;
-    const string setZZeroCustom;
+    const std::string probeCodeCustom;
+    const std::string zProbeResultVarCustom;
+    const std::string setZZeroCustom;
     const double XProbeDistRequired;
     const double YProbeDistRequired;
-    const string zwork;
-    const string zprobe;
-    const string zsafe;
-    const string zfail;
-    const string feedrate;
-    const string probeOn;
-    const string probeOff;
+    const std::string zwork;
+    const std::string zprobe;
+    const std::string zsafe;
+    const std::string zfail;
+    const std::string feedrate;
+    const std::string probeOn;
+    const std::string probeOff;
     const Software::Software software;
     const double quantization_error;
     const double xoffset;
@@ -125,22 +125,22 @@ public:
     const unsigned int xProbeNum;
     
     // Global variables
-    const string returnVar;
-    const string globalVar0;
-    const string globalVar1;
-    const string globalVar2;
-    const string globalVar3;
-    const string globalVar4;
-    const string globalVar5;
+    const std::string returnVar;
+    const std::string globalVar0;
+    const std::string globalVar1;
+    const std::string globalVar2;
+    const std::string globalVar3;
+    const std::string globalVar4;
+    const std::string globalVar5;
     
     const struct Tiling::TileInfo tileInfo;
     const unsigned int initialXOffsetVar;
     const unsigned int initialYOffsetVar;
 
-    static const string callSubRepeat[];
-    static const string probeCode[];
-    static const string zProbeResultVar[];
-    static const string setZZero[];
+    static const std::string callSubRepeat[];
+    static const std::string probeCode[];
+    static const std::string zProbeResultVar[];
+    static const std::string setZZero[];
 
 protected:
     double startPointX;
@@ -152,7 +152,7 @@ protected:
     double averageProbeDist;
     uniqueCodes *ocodes;
 
-    string callSub2[3];
+    std::string callSub2[3];
 
     icoordpair lastPoint;
 
@@ -164,11 +164,11 @@ protected:
 
     // getVarName returns the string containing the variable name associated with the probe point with
     // the indexes i and j
-    string getVarName( int i, int j );
+    std::string getVarName( int i, int j );
 
     // interpolatePoint finds the correct 4 probed points and computes a bilinear interpolation of point.
     // The result of the interpolation is saved in the parameter number RESULT_VAR
-    string interpolatePoint ( icoordpair point );
+    std::string interpolatePoint ( icoordpair point );
 
     // numOfSubsegments returns the right number of subsegments in order to approximate the line in the
     // best way possible

--- a/autoleveller.hpp
+++ b/autoleveller.hpp
@@ -27,18 +27,9 @@
 #define FIXED_FAIL_DEPTH_MM "-3"
 
 #include <string>
-using std::string;
-using std::to_string;
-
 #include <fstream>
-using std::endl;
-
 #include <vector>
-using std::vector;
-
 #include <memory>
-using std::shared_ptr;
-
 #include <boost/program_options.hpp>
 
 #include "geometry.hpp"
@@ -57,7 +48,7 @@ public:
     // prepareWorkarea computes the area of the milling project and computes the required number of probe
     // points; if it exceeds the maximum number of probe point it return false, otherwise it returns true
     // All the arguments must be in inches
-    bool prepareWorkarea( vector<shared_ptr<icoords> > &toolpaths );
+    bool prepareWorkarea( std::vector<std::shared_ptr<icoords> > &toolpaths );
 
     // header prints in of the header required for the probing (subroutines and probe calls for LinuxCNC,
     // only the probe calls for the other softwares)
@@ -166,7 +157,7 @@ protected:
     icoordpair lastPoint;
 
     //computeWorkarea computes the occupied rectangule of toolpaths
-    box_type_fp computeWorkarea( vector<shared_ptr<icoords> > &toolpaths );
+    box_type_fp computeWorkarea( std::vector<std::shared_ptr<icoords> > &toolpaths );
 
     // footerNoIf prints the footer, regardless of the software
     void footerNoIf( std::ofstream &of );
@@ -184,7 +175,7 @@ protected:
     unsigned int numOfSubsegments ( icoordpair point );
 
     // splitSegment splits the segment between lastPoint and point in n subsegments, and returns the
-    // icoords (aka vector<icoordpair>) containing them
+    // icoords (aka std::vector<icoordpair>) containing them
     icoords splitSegment ( const icoordpair point, const unsigned int n );
 };
 

--- a/available_drills.hpp
+++ b/available_drills.hpp
@@ -29,8 +29,8 @@ class AvailableDrill {
     out << ":" << negative_tolerance << ":+" << positive_tolerance;
     return out;
   }
-  void read(const string& input_string) {
-    std::vector<string> drill_parts;
+  void read(const std::string& input_string) {
+    std::vector<std::string> drill_parts;
     boost::split(drill_parts, input_string, boost::is_any_of(":"));
     switch (drill_parts.size()) {
       case 3:

--- a/board.cpp
+++ b/board.cpp
@@ -20,6 +20,9 @@
 
 #include "board.hpp"
 
+using std::get;
+using std::static_pointer_cast;
+
 typedef pair<string, shared_ptr<Layer> > layer_t;
 
 /******************************************************************************/

--- a/board.hpp
+++ b/board.hpp
@@ -27,25 +27,10 @@
 #include <sstream>
 
 #include <iostream>
-using std::cout;
-using std::endl;
-
 #include <map>
-using std::map;
 #include <vector>
-using std::vector;
-using std::pair;
-
 #include <memory>
-using std::shared_ptr;
-using std::dynamic_pointer_cast;
-using std::static_pointer_cast;
-
 #include <tuple>
-using std::tuple;
-using std::make_tuple;
-using std::get;
-
 #include "geometry.hpp"
 #include "surface.hpp"
 #include "surface_vectorial.hpp"
@@ -109,7 +94,7 @@ private:
      * prep_t tuples, whose signature must basically match the construction
      * signature of Layer.
      */
-    typedef tuple<shared_ptr<LayerImporter>, shared_ptr<RoutingMill>, bool> prep_t;
+    typedef std::tuple<shared_ptr<LayerImporter>, shared_ptr<RoutingMill>, bool> prep_t;
     map<string, prep_t> prepared_layers;
     map<string, shared_ptr<Layer> > layers;
 };

--- a/common.cpp
+++ b/common.cpp
@@ -24,6 +24,7 @@
 
 #include <boost/format.hpp>
 using boost::format;
+using std::string;
 
 #include "units.hpp"
 

--- a/common.hpp
+++ b/common.hpp
@@ -21,8 +21,6 @@
 #define COMMON_H
 
 #include <string>
-using std::string;
-
 #include <boost/program_options.hpp>
 
 namespace Software {
@@ -31,6 +29,6 @@ namespace Software {
 enum Software { CUSTOM = -1, LINUXCNC = 0, MACH4 = 1, MACH3 = 2 };
 };
 
-bool workSide( const boost::program_options::variables_map &options, string type );
+bool workSide( const boost::program_options::variables_map &options, std::string type );
 
 #endif // COMMON_H

--- a/core.cpp
+++ b/core.cpp
@@ -22,6 +22,8 @@
 #include <iostream>
 using std::cerr;
 using std::endl;
+using std::vector;
+using std::shared_ptr;
 
 #include "outline_bridges.hpp"
 

--- a/core.hpp
+++ b/core.hpp
@@ -21,14 +21,8 @@
 #define CORE_H
 
 #include <memory>
-using std::shared_ptr;
-
 #include <vector>
-using std::vector;
-
 #include <string>
-using std::string;
-
 #include "geometry.hpp"
 #include "mill.hpp"
 
@@ -40,14 +34,14 @@ using std::string;
 class Core
 {
 public:
-    virtual vector<shared_ptr<icoords> > get_toolpath(shared_ptr<RoutingMill> mill,
+    virtual std::vector<std::shared_ptr<icoords> > get_toolpath(std::shared_ptr<RoutingMill> mill,
             bool mirror) = 0;
-    virtual void save_debug_image(string message) = 0;
+    virtual void save_debug_image(std::string message) = 0;
     virtual ivalue_t get_width_in() = 0;
     virtual ivalue_t get_height_in() = 0;
-    virtual void add_mask(shared_ptr<Core>) = 0;
+    virtual void add_mask(std::shared_ptr<Core>) = 0;
     
-    virtual vector<size_t> get_bridges(shared_ptr<Cutter> cutter, shared_ptr<icoords> toolpath);
+    virtual std::vector<size_t> get_bridges(std::shared_ptr<Cutter> cutter, std::shared_ptr<icoords> toolpath);
 };
 
 #endif // IMPORTER_H

--- a/drill.cpp
+++ b/drill.cpp
@@ -44,6 +44,12 @@ using boost::format;
 #include <glibmm/miscutils.h>
 using Glib::build_filename;
 
+#include <string>
+using std::string;
+
+#include <map>
+using std::map;
+
 #include "drill.hpp"
 #include "tsp_solver.hpp"
 #include "common.hpp"

--- a/drill.hpp
+++ b/drill.hpp
@@ -24,23 +24,10 @@
 #define DRILL_H
 
 #include <map>
-using std::map;
-
 #include <string>
-using std::string;
-
 #include <list>
-using std::list;
-
 #include <vector>
-using std::vector;
-
-#include <map>
-using std::map;
-
 #include <memory>
-using std::shared_ptr;
-using std::unique_ptr;
 
 extern "C" {
 #include <gerbv.h>
@@ -68,7 +55,7 @@ class drillbit
 public:
     //Variables, constants, flags...
     double diameter;
-    string unit;
+    std::string unit;
     int drill_count;
     Length as_length() const {
         std::ostringstream os;
@@ -93,52 +80,52 @@ public:
     ExcellonProcessor(const boost::program_options::variables_map& options,
                       const icoordpair min, const icoordpair max);
     ~ExcellonProcessor();
-    void add_header(string);
-    void set_preamble(string);
-    void set_postamble(string);
+    void add_header(std::string);
+    void set_preamble(std::string);
+    void set_postamble(std::string);
     icoords line_to_holes(const ilinesegment& line, double drill_diameter);
-    void export_ngc(const string of_dir, const boost::optional<string>& of_name,
-                    shared_ptr<Driller> target, bool onedrill, bool nog81, bool zchange_absolute);
-    void export_ngc(const string of_dir, const boost::optional<string>& of_name,
-                    shared_ptr<Cutter> target, bool zchange_absolute);
+    void export_ngc(const std::string of_dir, const boost::optional<std::string>& of_name,
+                    std::shared_ptr<Driller> target, bool onedrill, bool nog81, bool zchange_absolute);
+    void export_ngc(const std::string of_dir, const boost::optional<std::string>& of_name,
+                    std::shared_ptr<Cutter> target, bool zchange_absolute);
 
-    shared_ptr< map<int, drillbit> > get_bits();
-    shared_ptr< map<int, ilinesegments> > get_holes();
+    std::shared_ptr< std::map<int, drillbit> > get_bits();
+    std::shared_ptr< std::map<int, ilinesegments> > get_holes();
 
 private:
-  gerbv_project_t* parse_project(const string& filename);
-  map<int, drillbit> parse_bits();
-  map<int, ilinesegments> parse_holes();
+  gerbv_project_t* parse_project(const std::string& filename);
+  std::map<int, drillbit> parse_bits();
+  std::map<int, ilinesegments> parse_holes();
 
     bool millhole(std::ofstream &of,
                   double start_x, double start_y,
                   double stop_x, double stop_y,
-                  shared_ptr<Cutter> cutter, double holediameter);
+                  std::shared_ptr<Cutter> cutter, double holediameter);
     double get_xvalue(double);
-    string drill_to_string(drillbit drillbit);
+    std::string drill_to_string(drillbit drillbit);
 
-  map<int, ilinesegments> optimize_holes(map<int, drillbit>& bits, bool onedrill,
+  std::map<int, ilinesegments> optimize_holes(std::map<int, drillbit>& bits, bool onedrill,
                                          const boost::optional<Length>& min_diameter,
                                          const boost::optional<Length>& max_diameter);
-  map<int, drillbit> optimize_bits(bool onedrill);
+  std::map<int, drillbit> optimize_bits(bool onedrill);
 
     void save_svg(
-        const map<int, drillbit>& bits, const map<int, ilinesegments>& holes,
-        const string& of_dir, const string& of_name);
+        const std::map<int, drillbit>& bits, const std::map<int, ilinesegments>& holes,
+        const std::string& of_dir, const std::string& of_name);
 
     const box_type_fp board_dimensions;
     const ivalue_t board_center_x;
 
     gerbv_project_t * const project;
-    const map<int, drillbit> parsed_bits;
-    const map<int, ilinesegments> parsed_holes;
-    vector<string> header;
-    string preamble;        //Preamble for output file
+    const std::map<int, drillbit> parsed_bits;
+    const std::map<int, ilinesegments> parsed_holes;
+    std::vector<std::string> header;
+    std::string preamble;        //Preamble for output file
 
-    string preamble_ext;    //Preamble from command line (user file)
-    string postamble_ext;   //Postamble from command line (user file)
+    std::string preamble_ext;    //Preamble from command line (user file)
+    std::string postamble_ext;   //Postamble from command line (user file)
     double cfactor;         //imperial/metric conversion factor for output file
-    string zchange;
+    std::string zchange;
     const bool drillfront;
     const double inputFactor;   //Multiply unitless inputs by this value.
     const bool bMetricOutput;   //Flag to indicate metric output

--- a/ngc_exporter.cpp
+++ b/ngc_exporter.cpp
@@ -29,6 +29,7 @@ using std::flush;
 using std::ios_base;
 using std::left;
 using std::to_string;
+using std::cout;
 
 #include <cmath>
 using std::ceil;

--- a/surface_vectorial.cpp
+++ b/surface_vectorial.cpp
@@ -41,6 +41,7 @@ using Glib::build_filename;
 using std::max;
 using std::max_element;
 using std::next;
+using std::dynamic_pointer_cast;
 
 unsigned int Surface_vectorial::debug_image_index = 0;
 

--- a/surface_vectorial.hpp
+++ b/surface_vectorial.hpp
@@ -25,22 +25,10 @@
 #include <forward_list>
 #include <map>
 #include <algorithm>
-using std::vector;
-using std::list;
-using std::forward_list;
-using std::map;
-using std::pair;
-using std::copy;
-using std::swap;
 
 #include <fstream>
-using std::ofstream;
 
 #include <memory>
-using std::shared_ptr;
-using std::dynamic_pointer_cast;
-using std::make_shared;
-using std::make_pair;
 
 #include <boost/noncopyable.hpp>
 
@@ -54,9 +42,8 @@ using std::make_pair;
 /*
  */
 /******************************************************************************/
-class Surface_vectorial: public Core, virtual public boost::noncopyable
-{
-public:
+class Surface_vectorial: public Core, virtual public boost::noncopyable {
+ public:
   Surface_vectorial(unsigned int points_per_circle, ivalue_t width, ivalue_t height,
                     string name, string outputdir, bool tsp_2opt, MillFeedDirection::MillFeedDirection mill_feed_direction);
 
@@ -138,7 +125,7 @@ public:
         int r = -1, int g = -1, int b = -1);
 
 protected:
-    ofstream output_file;
+    std::ofstream output_file;
     box_type_fp bounding_box;
     unique_ptr<bg::svg_mapper<point_type_fp> > mapper;
 };

--- a/tile.hpp
+++ b/tile.hpp
@@ -49,12 +49,12 @@ public:
     static TileInfo generateTileInfo( const boost::program_options::variables_map& options,
                                       uniqueCodes &ocodes, double boardHeight, double boardWidth );
 
-    inline void setGCodeEnd( string _gCodeEnd )
+    inline void setGCodeEnd( std::string _gCodeEnd )
     {
         gCodeEnd = _gCodeEnd;
     }
     
-    inline string getGCodeEnd()
+    inline std::string getGCodeEnd()
     {
         return gCodeEnd;
     }
@@ -65,7 +65,7 @@ public:
 private:
     void tileSequence( std::ofstream &of );
     
-    string gCodeEnd;
+    std::string gCodeEnd;
 };
 
 #endif // TILE_H

--- a/units.hpp
+++ b/units.hpp
@@ -474,7 +474,7 @@ class CommaSeparated {
     return out;
   }
   std::istream& read(std::istream& in) {
-    std::vector<string> unit_strings;
+    std::vector<std::string> unit_strings;
     std::string input_string(std::istreambuf_iterator<char>(in), {});
     boost::split(unit_strings, input_string, boost::is_any_of(","));
     for (const auto& unit_string : unit_strings) {


### PR DESCRIPTION
Putting using in header files pollutes the global space.  It can interfere with older boost builds, too.