### PR TITLE
Remove glib, gdk, and cairo from pcb2gcode binary.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,7 +61,7 @@ GERBV_VERSION = `pkg-config --modversion libgerbv`
 AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(glibmm_CFLAGS) $(gdkmm_CFLAGS) $(gerbv_CFLAGS) $(CODE_COVERAGE_CPPFLAGS) -DGIT_VERSION=\"$(GIT_VERSION)\"
 AM_CXXFLAGS = $(CODE_COVERAGE_CXXFLAGS) -DGIT_VERSION=\"$(GIT_VERSION)\" -DGERBV_VERSION=\"$(GERBV_VERSION)\"
 AM_LDFLAGS = $(BOOST_PROGRAM_OPTIONS_LDFLAGS)
-LIBS = $(glibmm_LIBS) $(gdkmm_LIBS) $(gerbv_LIBS) $(BOOST_PROGRAM_OPTIONS_LIBS) $(CODE_COVERAGE_LIBS)
+LIBS = $(gerbv_LIBS) $(BOOST_PROGRAM_OPTIONS_LIBS) $(CODE_COVERAGE_LIBS)
 
 EXTRA_DIST = millproject
 
@@ -76,7 +76,7 @@ tsp_solver_tests_SOURCES = tsp_solver_tests.cpp tsp_solver.hpp
 units_tests_SOURCES = units_tests.cpp units.hpp
 available_drills_tests_SOURCES = available_drills_tests.cpp available_drills.hpp
 gerberimporter_tests_SOURCES = gerberimporter.hpp gerberimporter.cpp gerberimporter_tests.cpp merge_near_points.hpp merge_near_points.cpp eulerian_paths.cpp eulerian_paths.hpp segmentize.cpp segmentize.hpp
-gerberimporter_tests_LDFLAGS = $(rsvg_LIBS)
+gerberimporter_tests_LDFLAGS = $(glibmm_LIBS) $(gdkmm_LIBS) $(rsvg_LIBS)
 options_tests_SOURCES = options_tests.cpp options.hpp options.cpp
 autoleveller_tests_SOURCES = autoleveller_tests.cpp autoleveller.hpp autoleveller.cpp options.cpp options.hpp
 

--- a/common.hpp
+++ b/common.hpp
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <boost/program_options.hpp>
+#include <boost/system/api_config.hpp>  // for BOOST_POSIX_API or BOOST_WINDOWS_API
 
 namespace Software {
 // This enum contains the software codes. Note that all the items (except for CUSTOM)
@@ -30,5 +31,17 @@ enum Software { CUSTOM = -1, LINUXCNC = 0, MACH4 = 1, MACH3 = 2 };
 };
 
 bool workSide( const boost::program_options::variables_map &options, std::string type );
+
+static inline std::string build_filename(const std::string& a, const std::string& b) {
+#ifdef BOOST_WINDOWS_API
+  static constexpr auto seperator = "\\";
+#endif
+
+#ifdef BOOST_POSIX_API
+  static constexpr auto seperator = "/";
+#endif
+
+  return a + seperator + b;
+}
 
 #endif // COMMON_H

--- a/drill.cpp
+++ b/drill.cpp
@@ -47,9 +47,6 @@ using std::fixed;
 #include <boost/format.hpp>
 using boost::format;
 
-#include <glibmm/miscutils.h>
-using Glib::build_filename;
-
 #include <string>
 using std::string;
 

--- a/gerberimporter.cpp
+++ b/gerberimporter.cpp
@@ -97,26 +97,6 @@ gdouble GerberImporter::get_max_y() const {
   return project->file[0]->image->info->max_y;
 }
 
-void GerberImporter::render(Cairo::RefPtr<Cairo::ImageSurface> surface, const guint dpi, const double min_x, const double min_y,
-                            const GdkColor& color, const gerbv_render_types_t& renderType) const {
-  gerbv_render_info_t render_info;
-
-  render_info.scaleFactorX = dpi;
-  render_info.scaleFactorY = dpi;
-  render_info.lowerLeftX = min_x;
-  render_info.lowerLeftY = min_y;
-  render_info.displayWidth = surface->get_width();
-  render_info.displayHeight = surface->get_height();
-  render_info.renderType = renderType;
-
-  project->file[0]->color = color;
-
-  Cairo::RefPtr<Cairo::Context> cr = Cairo::Context::create(surface);
-  gerbv_render_layer_to_cairo_target(cr->cobj(), project->file[0], &render_info);
-
-  /// @todo check wheter importing was successful
-}
-
 // Draw a regular polygon with outer diameter as specified and center.  The
 // number of vertices is provided.  offset is an angle in degrees to the
 // starting vertex of the shape.

--- a/gerberimporter.hpp
+++ b/gerberimporter.hpp
@@ -25,8 +25,6 @@
 #include <utility>
 #include <map>
 
-#include <cairomm/cairomm.h>
-
 #include "geometry.hpp"
 
 extern "C" {
@@ -45,29 +43,28 @@ class gerber_exception: public std::exception {};
 /******************************************************************************/
 class GerberImporter {
 public:
-    GerberImporter();
+  GerberImporter();
   bool load_file(const std::string& path);
-    virtual ~GerberImporter();
+  virtual ~GerberImporter();
 
-    virtual gdouble get_min_x() const;
-    virtual gdouble get_max_x() const;
-    virtual gdouble get_min_y() const;
-    virtual gdouble get_max_y() const;
+  virtual gdouble get_min_x() const;
+  virtual gdouble get_max_x() const;
+  virtual gdouble get_min_y() const;
+  virtual gdouble get_max_y() const;
 
-    virtual void render(Cairo::RefPtr<Cairo::ImageSurface> surface,
-                        const guint dpi, const double min_x,
-                        const double min_y, const GdkColor& color = { 0xFFFFFFFF, 0xFFFF, 0xFFFF, 0xFFFF },
-                        const gerbv_render_types_t& renderType = GERBV_RENDER_TYPE_CAIRO_NORMAL) const;
-    virtual std::pair<multi_polygon_type_fp, std::map<coordinate_type_fp, multi_linestring_type_fp>> render(
-        bool fill_closed_lines,
-        bool render_paths_to_shapes,
-        unsigned int points_per_circle) const;
+  virtual std::pair<multi_polygon_type_fp, std::map<coordinate_type_fp, multi_linestring_type_fp>> render(
+      bool fill_closed_lines,
+      bool render_paths_to_shapes,
+      unsigned int points_per_circle) const;
+  const gerbv_project_t* get_project() const {
+    return project;
+  }
 
 protected:
-    enum Side { FRONT = 0, BACK = 1 } side;
+  enum Side { FRONT = 0, BACK = 1 } side;
 
 private:
-    gerbv_project_t* project;
+  gerbv_project_t* project;
 };
 
 #endif // GERBERIMPORTER_H

--- a/main.cpp
+++ b/main.cpp
@@ -38,15 +38,6 @@ using std::shared_ptr;
 #include <string>
 using std::string;
 
-#include <glibmm/ustring.h>
-using Glib::ustring;
-
-#include <glibmm/init.h>
-#include <gdkmm/wrap_init.h>
-
-#include <glibmm/miscutils.h>
-using Glib::build_filename;
-
 #include "gerberimporter.hpp"
 #include "ngc_exporter.hpp"
 #include "board.hpp"
@@ -58,9 +49,6 @@ using Glib::build_filename;
 #include <boost/version.hpp>
 
 void do_pcb2gcode(int argc, const char* argv[]) {
-    Glib::init();
-    Gdk::wrap_init();
-
     options::parse(argc, argv);      //parse the command line parameters
 
     po::variables_map& vm = options::get_vm();      //get the cli parameters

--- a/ngc_exporter.cpp
+++ b/ngc_exporter.cpp
@@ -49,9 +49,6 @@ using std::dynamic_pointer_cast;
 
 #include <iomanip>
 
-#include <glibmm/miscutils.h>
-using Glib::build_filename;
-
 #include <boost/format.hpp>
 using boost::format;
 

--- a/surface_vectorial.cpp
+++ b/surface_vectorial.cpp
@@ -50,9 +50,6 @@ using std::map;
 using boost::optional;
 using boost::make_optional;
 
-#include <glibmm/miscutils.h>
-using Glib::build_filename;
-
 #include "tsp_solver.hpp"
 #include "surface_vectorial.hpp"
 #include "eulerian_paths.hpp"


### PR DESCRIPTION
But it is still used in gerberimporter_tests.