### PR TITLE
`brew upgrade wget` for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ install:
       brew install moreutils &&
       brew install gettext &&
       brew install librsvg &&
+      brew upgrade wget &&
       hash -r &&
       ln -s `which glibtoolize` $HOME/.local/bin/libtoolize &&
       ln -s `which glibtool` $HOME/.local/bin/libtool &&


### PR DESCRIPTION
Something changed and wget errors with:

dyld: Library not loaded: /usr/local/opt/openssl/lib/libssl.1.0.0.dylib

Upgrading fixes this.