### PR TITLE
fix y cfactor in mill-drill code

### DIFF
--- a/drill.cpp
+++ b/drill.cpp
@@ -530,7 +530,7 @@ bool ExcellonProcessor::millhole(std::ofstream &of, double start_x, double start
                << " J" << (stop_y-stop_targety) * cfactor << "\n";
             // Now back to the start of the first half circle
             of << "G1 X" << start_targetx * cfactor
-               << " Y" << start_targety;
+               << " Y" << start_targety * cfactor;
             if(stepcount != current_step) {
               of << " Z" << z * cfactor;
             }


### PR DESCRIPTION
Hello,
I've found on specific pcb diagram some weird conversion to g-code (from excellon file).
I found the bug, it was missing a '*cfactor' on start_targety value.
This PR fix the issue.

Regards,
pci.