### PR TITLE
keep millproject example up to date

### DIFF
--- a/millproject_example
+++ b/millproject_example
@@ -48,7 +48,6 @@ cut-infeed=10.0000
 cut-speed=10000
 cutter-diameter=3.0000
 fill-outline=true
-outline-width=0.2000
 zbridges=-0.6000
 zcut=-2.5000
 

--- a/millproject_example
+++ b/millproject_example
@@ -14,7 +14,6 @@
 #postamble=postamble.ngc
 
 # Common options
-dpi=1000
 metric=true
 metricoutput=true
 mirror-absolute=false


### PR DESCRIPTION
- remove `dpi` option, as removed in pcb2gcode/pcb2gcode@7a81066
- remove `outline-width` option, as removed in pcb2gcode/pcb2gcode@c24f63c

---

relates to Homebrew/homebrew-core#57001