### PR TITLE
Require geos 3.8.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ PKG_CHECK_MODULES([gerbv], [libgerbv >= 2.1.0])
 PKG_CHECK_MODULES([rsvg], [librsvg-2.0 >= 2.0])
 
 # Optional GEOS, as a slower but more reliable replacement for Boost geometry.
-GEOS_INIT
+GEOS_INIT([3.8.1])
 AS_IF([test "x$HAVE_GEOS" = "xyes"],
       [AC_MSG_NOTICE([Found geos, we'll use it instead of some of the boost geometry for greater accuracy though it can be slower.])],
       [AC_MSG_NOTICE([Didn't find geos, we'll use boost geometry for all geometry functions.  If you see inaccuracy, try geos.])])


### PR DESCRIPTION
Older versions of geos don't have a compatible c++ API.

If someone is unable to use geos 3.8.1 *and* finds that boost geometry isn't doing a good job, then I'll consider switching to the c API for supporting an older libgeos.