### PR TITLE
Unify tool output between milling and drilling

### DIFF
--- a/drill.cpp
+++ b/drill.cpp
@@ -172,7 +172,7 @@ string ExcellonProcessor::drill_to_string(drillbit drillbit) {
     }
     auto unit = bMetricOutput ? "mm" : "inch";
     std::ostringstream ss;
-    ss << diameter << " " << unit;
+    ss << diameter << unit;
     return ss.str();
 }
 

--- a/testing/gerbv_example/milldrilldiatest/expected/drill.ngc
+++ b/testing/gerbv_example/milldrilldiatest/expected/drill.ngc
@@ -2,7 +2,7 @@
 ( Software-independent Gcode )
 
 ( This file uses 4 drill bit sizes. )
-( Bit sizes: [0.4 mm] [0.6 mm] [0.8 mm] [1 mm] )
+( Bit sizes: [0.4mm] [0.6mm] [0.8mm] [1mm] )
 
 G94       (Millimeters per minute feed rate.)
 G21       (Units == Millimeters.)
@@ -14,7 +14,7 @@ G00 Z10.00000 (Retract)
 T1
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 0.4 mm)
+(MSG, Change tool bit to drill size 0.4mm)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)
@@ -29,7 +29,7 @@ G00 Z10.00000 (Retract)
 T3
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 0.6 mm)
+(MSG, Change tool bit to drill size 0.6mm)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)
@@ -43,7 +43,7 @@ G00 Z10.00000 (Retract)
 T4
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 0.8 mm)
+(MSG, Change tool bit to drill size 0.8mm)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)
@@ -57,7 +57,7 @@ G00 Z10.00000 (Retract)
 T5
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 1 mm)
+(MSG, Change tool bit to drill size 1mm)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)

--- a/testing/gerbv_example/milldrilldiatest/expected/milldrill.ngc
+++ b/testing/gerbv_example/milldrilldiatest/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 1.00000mm to drill the 5 hole sizes. )
-( Hole sizes: [1.2 mm] [1.4 mm] [1.6 mm] [1.8 mm] [2 mm] )
+( Hole sizes: [1.2mm] [1.4mm] [1.6mm] [1.8mm] [2mm] )
 
 G94       (Millimeters per minute feed rate.)
 G21       (Units == Millimeters.)

--- a/testing/gerbv_example/multivibrator-basename/expected/testbase_name_milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-basename/expected/testbase_name_milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-clockwise/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-clockwise/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.07087inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0787795 inch] )
+( Hole sizes: [0.0314961inch] [0.0787795inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-contentions/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-contentions/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-extra-passes-big/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-extra-passes-big/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-extra-passes-two-isolators-tiles-al/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-extra-passes-two-isolators-tiles-al/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Gcode for linuxcnc )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-extra-passes-two-isolators-tiles/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-extra-passes-two-isolators-tiles/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-extra-passes-two-isolators/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-extra-passes-two-isolators/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-extra-passes-voronoi/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-extra-passes-voronoi/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-extra-passes/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-extra-passes/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-identical-isolators/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-identical-isolators/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-no-tsp-2opt/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-no-tsp-2opt/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-no-zbridges/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-no-zbridges/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator-two-isolators/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator-two-isolators/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator_backtrack/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator_backtrack/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator_no_optimise/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator_no_optimise/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator_no_zero_start/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator_no_zero_start/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator_pre_post_milling_gcode/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator_pre_post_milling_gcode/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 ( preamble-text line1 )
 ( preamble-text line2 )

--- a/testing/gerbv_example/multivibrator_xy_offset/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator_xy_offset/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/multivibrator_xy_offset_zero_start/expected/milldrill.ngc
+++ b/testing/gerbv_example/multivibrator_xy_offset_zero_start/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.03150inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0314961 inch] [0.0394094 inch] )
+( Hole sizes: [0.0314961inch] [0.0394094inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/slots-milldrill-metric/expected/milldrill.ngc
+++ b/testing/gerbv_example/slots-milldrill-metric/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 2.54000mm to drill the 3 hole sizes. )
-( Hole sizes: [0.4 mm] [1.001 mm] [3 mm] )
+( Hole sizes: [0.4mm] [1.001mm] [3mm] )
 
 G94       (Millimeters per minute feed rate.)
 G21       (Units == Millimeters.)

--- a/testing/gerbv_example/slots-milldrill/expected/milldrill.ngc
+++ b/testing/gerbv_example/slots-milldrill/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.10000inch to drill the 3 hole sizes. )
-( Hole sizes: [0.015748 inch] [0.0394094 inch] [0.11811 inch] )
+( Hole sizes: [0.015748inch] [0.0394094inch] [0.11811inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/slots-with-drill-and-milldrill/expected/drill.ngc
+++ b/testing/gerbv_example/slots-with-drill-and-milldrill/expected/drill.ngc
@@ -2,7 +2,7 @@
 ( Software-independent Gcode )
 
 ( This file uses 1 drill bit sizes. )
-( Bit sizes: [0.015748 inch] )
+( Bit sizes: [0.015748inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)
@@ -14,7 +14,7 @@ G00 Z1.00000 (Retract)
 T1
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 0.015748 inch)
+(MSG, Change tool bit to drill size 0.015748inch)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)

--- a/testing/gerbv_example/slots-with-drill-and-milldrill/expected/milldrill.ngc
+++ b/testing/gerbv_example/slots-with-drill-and-milldrill/expected/milldrill.ngc
@@ -1,7 +1,7 @@
 ( pcb2gcode 2.1.0 )
 ( Software-independent Gcode )
 ( This file uses a mill head of 0.04000inch to drill the 2 hole sizes. )
-( Hole sizes: [0.0394094 inch] [0.11811 inch] )
+( Hole sizes: [0.0394094inch] [0.11811inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)

--- a/testing/gerbv_example/slots-with-drill-metric/expected/drill.ngc
+++ b/testing/gerbv_example/slots-with-drill-metric/expected/drill.ngc
@@ -13,7 +13,7 @@ G53 G00 Z25.40000 (Retract)
 T1
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 0.4064 mm)
+(MSG, Change tool bit to drill size 0.4064mm)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)

--- a/testing/gerbv_example/slots-with-drill/expected/drill.ngc
+++ b/testing/gerbv_example/slots-with-drill/expected/drill.ngc
@@ -2,7 +2,7 @@
 ( Software-independent Gcode )
 
 ( This file uses 3 drill bit sizes. )
-( Bit sizes: [0.015748 inch] [0.0394094 inch] [0.11811 inch] )
+( Bit sizes: [0.015748inch] [0.0394094inch] [0.11811inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)
@@ -14,7 +14,7 @@ G00 Z1.00000 (Retract)
 T1
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 0.015748 inch)
+(MSG, Change tool bit to drill size 0.015748inch)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)
@@ -37,7 +37,7 @@ G00 Z1.00000 (Retract)
 T2
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 0.0394094 inch)
+(MSG, Change tool bit to drill size 0.0394094inch)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)
@@ -82,7 +82,7 @@ G00 Z1.00000 (Retract)
 T3
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 0.11811 inch)
+(MSG, Change tool bit to drill size 0.11811inch)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)

--- a/testing/gerbv_example/slots-with-drills-available/expected/drill.ngc
+++ b/testing/gerbv_example/slots-with-drills-available/expected/drill.ngc
@@ -2,7 +2,7 @@
 ( Software-independent Gcode )
 
 ( This file uses 3 drill bit sizes. )
-( Bit sizes: [0.01 inch] [0.0394094 inch] [0.11811 inch] )
+( Bit sizes: [0.01inch] [0.0394094inch] [0.11811inch] )
 
 G94       (Inches per minute feed rate.)
 G20       (Units == INCHES.)
@@ -14,7 +14,7 @@ G00 Z1.00000 (Retract)
 T1
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 0.01 inch)
+(MSG, Change tool bit to drill size 0.01inch)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)
@@ -37,7 +37,7 @@ G00 Z1.00000 (Retract)
 T2
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 0.0394094 inch)
+(MSG, Change tool bit to drill size 0.0394094inch)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)
@@ -82,7 +82,7 @@ G00 Z1.00000 (Retract)
 T3
 M5      (Spindle stop.)
 G04 P1.00000
-(MSG, Change tool bit to drill size 0.11811 inch)
+(MSG, Change tool bit to drill size 0.11811inch)
 M6      (Tool change.)
 M0      (Temporary machine stop.)
 M3      (Spindle on clockwise.)


### PR DESCRIPTION
In #236 the following script is proposed to split the mill files into one for each tool (cutter diameter):
https://github.com/pcb2gcode/pcb2gcode/files/2914413/split-gcode.txt

This script does not work as-is for drill files to split them into individual files for differently sized drills. The reason is that tool size messages are formatted differently, for example:
```(MSG, Change tool bit to drill size 0.4 mm)```
vs:
```(MSG, Change tool bit to mill diameter 1.20000mm)```

Notice the additional space in the drill tool change message.

This patch removes the space between diameter and unit for drill size output, making the script usable for both drill and mill files.