### PR TITLE
Redirect output of time in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
               time valgrind --error-exitcode=127 --errors-for-leak-kinds=definite --leak-check=full -- ../../../pcb2gcode || exit;
             fi;
             echo "Finished on {}";
-          popd } 2>&1'
+          popd; } 2>&1'
         popd
     - name: Reset coverage
       if: matrix.code_coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,18 +263,18 @@ jobs:
       run: |
         pushd testing/gerbv_example
         ls | parallel -k -j ${NUM_CPUS} --halt soon,fail=1 '
-          pushd {};
-          echo "Running on {}";
-          if [[ -f "no-valgrind" ]]; then
-            cat no-valgrind;
-          fi;
-          if [[ -f "no-valgrind" || "${{ matrix.os }}" != "ubuntu" ]]; then
-            time ../../../pcb2gcode || exit;
-          else
-            time valgrind --error-exitcode=127 --errors-for-leak-kinds=definite --leak-check=full -- ../../../pcb2gcode || exit;
-          fi;
-          echo "Finished on {}";
-          popd'
+          { pushd {};
+            echo "Running on {}";
+            if [[ -f "no-valgrind" ]]; then
+              cat no-valgrind;
+            fi;
+            if [[ -f "no-valgrind" || "${{ matrix.os }}" != "ubuntu" ]]; then
+              time ../../../pcb2gcode || exit;
+            else
+              time valgrind --error-exitcode=127 --errors-for-leak-kinds=definite --leak-check=full -- ../../../pcb2gcode || exit;
+            fi;
+            echo "Finished on {}";
+          popd } 2>&1'
         popd
     - name: Reset coverage
       if: matrix.code_coverage


### PR DESCRIPTION
The time command outputs to stderr and not stdout so it wasn't
displaying together with the output of the commands run under
parallel.