### PR TITLE
perf: Only mask when there's no mask if no voronoi

### DIFF
--- a/surface_vectorial.cpp
+++ b/surface_vectorial.cpp
@@ -1105,10 +1105,10 @@ vector<multi_polygon_type_fp> Surface_vectorial::offset_polygon(
       double factor = (1-double(steps+2))/2;
       auto expand_by = (diameter - overlap) * factor;
       bg::buffer(bounding_box, new_bounding_box, -expand_by);
+      milling_poly = milling_poly & new_bounding_box;
     } else {
       bg::buffer(bounding_box, new_bounding_box, diameter / 2 + (diameter - overlap) * (steps - 1));
     }
-    milling_poly = milling_poly & new_bounding_box;
   }
 
   vector<multi_polygon_type_fp> polygons;


### PR DESCRIPTION
This probably doesn't have any significant impact on performance but
it's surely not any worse than before and correctness is unaffected.