### PR TITLE
Use valgrind with clang again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,10 +269,10 @@ jobs:
             if [[ -f "no-valgrind" ]]; then
               cat no-valgrind;
             fi;
-            if [[ -f "no-valgrind" || "${{ matrix.os }}" != "ubuntu" || "${{ matrix.compiler }}" == "clang++" ]]; then
+            if [[ -f "no-valgrind" || "${{ matrix.os }}" != "ubuntu" ]]; then
               time ../../../pcb2gcode || exit;
             else
-              time valgrind --error-exitcode=127 --errors-for-leak-kinds=definite --leak-check=full -- ../../../pcb2gcode || exit;
+              time valgrind --error-exitcode=127 --errors-for-leak-kinds=definite --leak-check=full -s --exit-on-first-error=yes --expensive-definedness-checks=yes -- ../../../pcb2gcode || exit;
             fi;
             popd;
             echo "::endgroup::";
@@ -283,13 +283,13 @@ jobs:
       continue-on-error: true
       run: lcov --directory . -z
     - name: Run unit tests
-      if: matrix.os != 'ubuntu' || matrix.compiler == 'clang++'
+      if: matrix.os != 'ubuntu'
       env:
         VERBOSE: 1
         SKIP_GERBERIMPORTER_TESTS_PNG: 1
       run: make -j ${NUM_CPUS} check || (cat test-suite.log && false)
     - name: Run unit tests with valgrind
-      if: matrix.os == 'ubuntu' && matrix.compiler != 'clang++'
+      if: matrix.os == 'ubuntu'
       env:
         VERBOSE: 1
         SKIP_GERBERIMPORTER_TESTS_PNG: 1

--- a/Makefile.am
+++ b/Makefile.am
@@ -107,7 +107,7 @@ segment_tree_tests_SOURCES = segment_tree_tests.cpp segment_tree.cpp boost_unit_
 TESTS = $(check_PROGRAMS)
 
 @VALGRIND_CHECK_RULES@
-VALGRIND_FLAGS = --error-exitcode=127 --errors-for-leak-kinds=definite --show-leak-kinds=definite --leak-check=full
+VALGRIND_FLAGS = --error-exitcode=127 --errors-for-leak-kinds=definite --show-leak-kinds=definite --leak-check=full -s --exit-on-first-error=yes --expensive-definedness-checks=yes
 
 check-syntax:
 	timeout 10 $(COMPILE) -o /dev/null -S ${CHK_SOURCES} || true


### PR DESCRIPTION
Now that we have a version of Valgrind that works a little better, we can use Valgrind with clang.