### PR TITLE
fix: Close unclosed contours

### DIFF
--- a/gerberimporter.cpp
+++ b/gerberimporter.cpp
@@ -815,7 +815,10 @@ pair<multi_polygon_type_fp, map<coordinate_type_fp, multi_linestring_type_fp>> G
         }
       } else if (currentNet->aperture_state == GERBV_APERTURE_STATE_OFF) {
         if (contour) {
-          bg::append(region, stop);
+          if (region.size() > 0 && region.front() != region.back()) {
+            cerr << "Repairing invalid contour (EasyEDA makes these sometimes): " << bg::wkt(region) << std::endl;
+            bg::append(region, region.front());
+          }
           draws.push_back(simplify_cutins(region));
           region.clear();
         }
@@ -826,6 +829,10 @@ pair<multi_polygon_type_fp, map<coordinate_type_fp, multi_linestring_type_fp>> G
       contour = true;
     } else if (currentNet->interpolation == GERBV_INTERPOLATION_PAREA_END) {
       contour = false;
+      if (region.size() > 0 && region.front() != region.back()) {
+        cerr << "Repairing invalid contour (EasyEDA makes these sometimes): " << bg::wkt(region) << std::endl;
+        bg::append(region, region.front());
+      }
       draws.push_back(simplify_cutins(region));
       region.clear();
     } else if (currentNet->interpolation == GERBV_INTERPOLATION_CW_CIRCULAR ||

--- a/gerberimporter_tests.cpp
+++ b/gerberimporter_tests.cpp
@@ -279,6 +279,7 @@ BOOST_DATA_TEST_CASE(gerberimporter_match_gerbv,
                            {"g01_rectangle.gbr",           0.0008},
                            {"moire.gbr",                   0.020},
                            {"thermal.gbr",                 0.011},
+                           {"unclosed_contour.gbr",        0.0003},
                            {"cutins.gbr",                  0.000}}),
                      gerber_file, max_error_rate) {
   const char *skip_test = std::getenv("SKIP_GERBERIMPORTER_TESTS");

--- a/testing/gerberimporter/unclosed_contour.gbr
+++ b/testing/gerberimporter/unclosed_contour.gbr
@@ -1,0 +1,33 @@
+G04 This is an RS-274x file exported by *
+G04 gerbv version 2.7A *
+G04 More information is available about gerbv at *
+G04 http://gerbv.geda-project.org/ *
+G04 --End of header info--*
+%MOIN*%
+%FSLAX24Y24*%
+%OFA0.0000B0.0000*%
+G90*
+
+G04 --Define apertures--*
+%ADD10C,0.0197*%
+%ADD11C,0.0600*%
+%ADD12R,0.0620X0.0620*%
+%ADD13C,0.0620*%
+%ADD14C,0.0276*%
+%ADD15R,0.1102X0.1575*%
+G04 --Start main section--*
+G54D15*
+G36*
+X0Y50000D02*
+Y100000D01*
+X100000D01*
+Y0D01*
+X0D01*
+
+X-10000Y50000D02*
+X-50000Y10000D01*
+X-90000Y50000D01*
+X-50000Y90000D01*
+
+G37*
+M02*


### PR DESCRIPTION
According to the [Gerber Format
Specification](https://www.bosco.co.za/DownloadDocs/The_Gerber_Format_Specification.pdf)
section 4.6.1, a contour may only be ended by a D02 or G37 when the
contour is closed.  For example, a rectangle must have four line
segments, not three.

EasyEDA seems to be making shapes missing a line segment and assumes
that interpreters will close the contour.  `pcb2gcode` can support
this by checking that the region is closed.  If not, add a point at
the end which matches the first point so that the contour is closed.

This fixes #577