### PR TITLE
fix: don't warn when rounding by less than 1 micro-inch

### DIFF
--- a/drill.cpp
+++ b/drill.cpp
@@ -848,7 +848,7 @@ map<int, drillbit> ExcellonProcessor::optimize_bits() {
                         b.difference(wanted_length, inputFactor).value_or(std::numeric_limits<double>::infinity());
                 });
 
-            auto difference = best_available_drill->difference(wanted_length, inputFactor);
+            const auto difference = best_available_drill->difference(wanted_length, inputFactor);
             if (difference) {
                 wanted_drill_bit.diameter = best_available_drill->diameter().asInch(inputFactor);
                 wanted_drill_bit.unit = "inch";

--- a/drill.cpp
+++ b/drill.cpp
@@ -343,8 +343,8 @@ void ExcellonProcessor::export_ngc(const string of_dir, const boost::optional<st
                         {
                             of << "G0 X" << ( ( get_xvalue(x) - xoffsetTot ) * cfactor)
                                <<   " Y" << ( ( get_yvalue(y) - yoffsetTot ) * cfactor) << "\n";
-                            of << "G1 Z" << driller->zwork * cfactor << '\n';
-                            of << "G1 Z" << driller->zsafe * cfactor << '\n';
+                            of << "G1 Z" << driller->zwork * cfactor << " F" << driller->feed * cfactor << '\n';
+                            of << "G1 Z" << driller->zsafe * cfactor << " F120" << '\n';
                         }
                         else
                         {
@@ -852,7 +852,7 @@ map<int, drillbit> ExcellonProcessor::optimize_bits() {
             if (difference) {
                 wanted_drill_bit.diameter = best_available_drill->diameter().asInch(inputFactor);
                 wanted_drill_bit.unit = "inch";
-                if (difference && abs(*difference) > 1e-6) {
+                if (abs(*difference) > 1e-6) {
                     cerr << "Info: bit " << wanted_drill.first << " ("
                        << old_string << ") is rounded to "
                        << drill_to_string(wanted_drill_bit) << std::endl;

--- a/drill.cpp
+++ b/drill.cpp
@@ -852,7 +852,7 @@ map<int, drillbit> ExcellonProcessor::optimize_bits() {
             if (difference) {
                 wanted_drill_bit.diameter = best_available_drill->diameter().asInch(inputFactor);
                 wanted_drill_bit.unit = "inch";
-                if (difference > 1e-6 || difference < -1e-6) {
+                if (difference && abs(*difference) > 1e-6) {
                     cerr << "Info: bit " << wanted_drill.first << " ("
                        << old_string << ") is rounded to "
                        << drill_to_string(wanted_drill_bit) << std::endl;

--- a/drill.cpp
+++ b/drill.cpp
@@ -847,12 +847,16 @@ map<int, drillbit> ExcellonProcessor::optimize_bits() {
                     return a.difference(wanted_length, inputFactor).value_or(std::numeric_limits<double>::infinity()) <
                         b.difference(wanted_length, inputFactor).value_or(std::numeric_limits<double>::infinity());
                 });
-            if (best_available_drill->difference(wanted_length, inputFactor)) {
+
+            auto difference = best_available_drill->difference(wanted_length, inputFactor);
+            if (difference) {
                 wanted_drill_bit.diameter = best_available_drill->diameter().asInch(inputFactor);
                 wanted_drill_bit.unit = "inch";
-                cerr << "Info: bit " << wanted_drill.first << " ("
-                   << old_string << ") is rounded to "
-                   << drill_to_string(wanted_drill_bit) << std::endl;
+                if (difference > 1e-6 || difference < -1e-6) {
+                    cerr << "Info: bit " << wanted_drill.first << " ("
+                       << old_string << ") is rounded to "
+                       << drill_to_string(wanted_drill_bit) << std::endl;
+                }
             }
         }
     }

--- a/drill.cpp
+++ b/drill.cpp
@@ -343,8 +343,8 @@ void ExcellonProcessor::export_ngc(const string of_dir, const boost::optional<st
                         {
                             of << "G0 X" << ( ( get_xvalue(x) - xoffsetTot ) * cfactor)
                                <<   " Y" << ( ( get_yvalue(y) - yoffsetTot ) * cfactor) << "\n";
-                            of << "G1 Z" << driller->zwork * cfactor << " F" << driller->feed * cfactor << '\n';
-                            of << "G1 Z" << driller->zsafe * cfactor << " F120" << '\n';
+                            of << "G1 Z" << driller->zwork * cfactor << '\n';
+                            of << "G1 Z" << driller->zsafe * cfactor << '\n';
                         }
                         else
                         {


### PR DESCRIPTION
When working in metric units, `pcb2gcode` is giving warnings like
```
Exporting drill... Info: bit 1 (0.8mm) is rounded to 0.8mm
Info: bit 2 (0.9mm) is rounded to 0.9mm
Info: bit 3 (1mm) is rounded to 1mm
Info: bit 4 (3.2mm) is rounded to 3.2mm
```

With this patch, warnings are only printed when the amount of rounding was more than 1 micro-inch.