### PR TITLE
Add support for global millproject file

### DIFF
--- a/options.cpp
+++ b/options.cpp
@@ -165,7 +165,27 @@ string options::help()
 void options::parse_files()
 {
 
+    std::string global_file("~/.millproject");
     std::string file("millproject");
+
+    char const* home = getenv("HOME");
+    if (home or ((home = getenv("USERPROFILE")))) {
+        global_file.replace(0, 1, home);
+    } else {
+        char const *hdrive = getenv("HOMEDRIVE"), *hpath = getenv("HOMEPATH");
+        assert(hdrive);
+        assert(hpath);
+        global_file.replace(0, 1, std::string(hdrive) + hpath);
+    }
+
+    try {
+        std::ifstream stream(global_file.c_str());
+        po::store(po::parse_config_file(stream, instance().cfg_options),
+                  instance().vm);
+    } catch (std::exception& e) {
+      maybe_throw("Error parsing configuration file \"" + global_file + "\": " +
+                  e.what(), ERR_INVALIDPARAMETER);
+    }
 
     try {
         std::ifstream stream(file.c_str());


### PR DESCRIPTION
I hacked support for a global millproject file. It would be very useful for me as I don't have to redefine everything every time and can just over-write option in a per-project manner and I think a lot of other people have the same workflow/need. Would you be interested in such a functionality?

My C++ knowledge is lacking (and I think it shows even from a 5 line contribution) so I'd like any pointers to make this contribution passable (probably split the homedir expansion in a different function somewhere outside of `options.cpp`, add man page reference, add it to the readme/wiki, add unit tests, etc.)