### PR TITLE
ci: Temporarily disable macos and windows CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         geos: ['3.11.0', 'none']
         compiler: ['g++', 'g++-8', 'clang++']
         exclude:
+          - os: macos # Temporarily disable until fixed
+          - os: windows # Temporarily disable until fixed
           - os: macos
             boost: '1_66'
           - os: ubuntu
@@ -38,15 +40,15 @@ jobs:
             compiler: g++-8
             geos: '3.11.0'
             code_coverage: "--enable-code-coverage"
-          - os: windows
-            shell: msys2 {0}
-            local_install_path: '/d/a/pcb2gcode/.local'
+          #- os: windows
+          #  shell: msys2 {0}
+          #  local_install_path: '/d/a/pcb2gcode/.local'
           - os: ubuntu
             shell: '/usr/bin/bash -l -e -o pipefail {0}'
             local_install_path: '$HOME/.local'
-          - os: macos
-            shell: '/bin/bash -l -e -o pipefail {0}'
-            local_install_path: '$HOME/.local'
+          #- os: macos
+          #  shell: '/bin/bash -l -e -o pipefail {0}'
+          #  local_install_path: '$HOME/.local'
     runs-on: ${{ matrix.os }}-latest
     defaults:
       run:


### PR DESCRIPTION
They've broken and we don't know why.  Disable until they are fixed.