### PR TITLE
ci: Use fewer CPUs on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Windows specific setup
       if: matrix.os == 'windows'
       run: |
-        echo "export NUM_CPUS='$((`nproc --all` * 4))'" >> ~/.bash_profile
+        echo "export NUM_CPUS='$((`nproc --all`))'" >> ~/.bash_profile
     - name: Ubuntu specific setup
       if: matrix.os == 'ubuntu'
       run: |


### PR DESCRIPTION
Windows CI is failing with out of memory sporadically.  Maybe using
fewer CPUs will help?