### PR TITLE
ci: Use new GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,11 +130,11 @@ jobs:
     - name: Sanitize cache key
       id: sanitize-key
       run: |
-        echo "::set-output name=key::$(echo '${{ matrix.os }}_${{ matrix.boost }}_${{ matrix.compiler }}_${{ matrix.geos }}' | sed 's/+/plus/g')"
+        echo "key=$(echo '${{ matrix.os }}_${{ matrix.boost }}_${{ matrix.compiler }}_${{ matrix.geos }}' | sed 's/+/plus/g')" >> $GITHUB_OUTPUT
         if command -v cygpath; then
-          echo "::set-output name=path::$(cygpath -w ${{ matrix.local_install_path }})"
+          echo "path=$(cygpath -w ${{ matrix.local_install_path }})" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=path::${{ matrix.local_install_path }}"
+          echo "path=${{ matrix.local_install_path }}" >> $GITHUB_OUTPUT
         fi
     - name: Cache local install path
       uses: eyal0/cache@main


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Use the new way of making outputs.