### PR TITLE
work around Eulerian paths bug causing #687 and #688

### DIFF
--- a/eulerian_paths.hpp
+++ b/eulerian_paths.hpp
@@ -124,9 +124,13 @@ class eulerian_paths {
     // if we make a path from one, it is sure to end back where it started.
     // We'll go over all our current Euler paths and stitch in loops anywhere
     // that there is an unvisited edge.
+    std::vector<std::pair<linestring_t, bool>> extra_paths;
     for (auto& euler_path : euler_paths) {
-      stitch_loops(&euler_path);
+      stitch_loops(&euler_path, &extra_paths);
     }
+
+    euler_paths.insert(euler_paths.end(), extra_paths.begin(), extra_paths.end());
+    extra_paths.clear();
 
     // Anything remaining is loops on islands.  Make all those paths, too.
     // Prefer directional edges so do those first.
@@ -139,10 +143,12 @@ class eulerian_paths {
         new_path.second = reversible;
         // We can stitch right now because all vertices already have even number
         // of edges.
-        stitch_loops(&new_path);
+        stitch_loops(&new_path, &extra_paths);
         euler_paths.push_back(new_path);
       }
     }
+
+    euler_paths.insert(euler_paths.end(), extra_paths.begin(), extra_paths.end());
 
     return euler_paths;
   }
@@ -300,7 +306,9 @@ class eulerian_paths {
   // and stitch it into the current path.  Because all paths have the same
   // number of in and out, the stitch can only possibly end in a loop.  This
   // continues until the end of the path.
-  void stitch_loops(std::pair<linestring_t, bool> *euler_path) {
+  void stitch_loops(
+      std::pair<linestring_t, bool> *euler_path,
+      std::vector<std::pair<linestring_t, bool>> *extra_paths) {
     // Use a counter and not a pointer because the list will grow and pointers
     // may be invalidated.
     linestring_t new_loop;
@@ -309,9 +317,16 @@ class eulerian_paths {
       bool new_loop_reversible = make_path(euler_path->first[i], &new_loop);
       // Did this vertex have any unvisited edges?
       if (new_loop.size() > 0) {
-        // Now we stitch it in.
-        euler_path->first.insert(euler_path->first.begin()+i+1, new_loop.begin(), new_loop.end());
-        euler_path->second = euler_path->second && new_loop_reversible;
+        if (new_loop.back() == euler_path->first[i]) {
+          // Now we stitch it in.
+          euler_path->first.insert(euler_path->first.begin()+i+1, new_loop.begin(), new_loop.end());
+          euler_path->second = euler_path->second && new_loop_reversible;
+        } else {
+          // something went wrong and the path is not a loop; add the start
+          // vertex and treat it as a new path
+          new_loop.insert(new_loop.begin(), euler_path->first[i]);
+          extra_paths->push_back(std::make_pair(new_loop, new_loop_reversible));
+        }
         new_loop.clear(); // Prepare for the next one.
       }
     }


### PR DESCRIPTION
This is a work-around for issues like #687 and #688.

I've spent a few evenings debugging this, and the problem is in the Eulerian paths code. The paths are valid at the input, and not at the output, because `sitich_loop` sometimes finds a path which is not a loop, and splices it in the middle of another path, causing an arbitrary jump.

The ultimate cause of this is not completely clear to me yet. I think the code is well-behaved, but I'm suspicious of the algorithm. Specifically The conditions for Eulerian paths on mixed graphs are a bit more complex than those for directed/undirected graphs:

https://en.wikipedia.org/wiki/Eulerian_path#Mixed_Eulerian_graphs

It seems like the application of Hierholzer's algorithm to mixed graphs might not be straightforward. As a concrete example, I don't think the assumptions in this comment hold:

https://github.com/pcb2gcode/pcb2gcode/blob/520920ed0599ecae0c2c9c7f7c62634fc7bea267/eulerian_paths.hpp#L122-L126

With something like this at that position, plenty of vertices with odd edge counts can be seen in problematic examples:

```cpp
for (const auto& vertex : all_start_vertices) {
  auto out_edges = start_vertex_to_unvisited_path_index.count(vertex);
  auto in_edges = end_vertex_to_unvisited_path_index.count(vertex);
  auto bidi_edges = bidi_vertex_to_unvisited_path_index.count(vertex);

  if ((bidi_edges - std::abs((int)out_edges - (int)in_edges)) % 2 != 0) {
    std::cout << "bad vertex: " << out_edges << " " << in_edges << " " << bidi_edges << "\n";
  }
}
```

The work-around is to detect unclosed loops in `stitch_loops`, and add them as new paths instead. These are buffered to avoid invalidating iterators or references. It would be good to document the cause/work-around in the code, but I'd rather wait until we understand it better (or give up).

There are probably some failing tests which need tidying up. As part of finding this I wrote a script to find minimal examples by running pcb2gcode on randomly-generated gerbers and checking the output. With this change this no longer finds any issues. I've attached a minimal example for completeness:

[minimal_example.zip](https://github.com/user-attachments/files/24117769/minimal_example.zip)

This fails with current master ( 520920ed0599ecae0c2c9c7f7c62634fc7bea267 ) and:

```
Boost: 108700
Gerbv: 2.10.0
Geos: Not installed
```

The related issues mention a boost change as a possible cause. I think this is a red herring; I saw failures with boost 1.77 too. Very minor geometry changes can cause large changes in graph topology, which triggers or avoids the bug.
