### PR TITLE
Remove small Voronoi artifacts from output

### DIFF
--- a/ngc_exporter.cpp
+++ b/ngc_exporter.cpp
@@ -78,7 +78,10 @@ void NGC_Exporter::export_all(boost::program_options::variables_map& options)
     bMetricoutput = options["metricoutput"].as<bool>();      //set flag for metric output
     bZchangeG53 = options["zchange-absolute"].as<bool>();
     nom6 = options["nom6"].as<bool>();
-    
+
+    // Minimum path length - paths shorter than this are skipped (removes Voronoi artifacts)
+    min_path_length = options["min-path-length"].as<Length>().asInch(bMetricinput ? 1.0/25.4 : 1);
+
     string outputdir = options["output-dir"].as<string>();
     
     //set imperial/metric conversion factor for output coordinates depending on metricoutput option
@@ -367,6 +370,9 @@ void NGC_Exporter::export_layer(shared_ptr<Layer> layer, string of_name, boost::
             const linestring_type_fp& path = toolpaths[path_index];
             if (path.size() < 1) {
               continue; // Empty path.
+            }
+            if (min_path_length > 0 && bg::length(path) < min_path_length) {
+              continue; // Path too short (Voronoi artifact).
             }
 
             // retract, move to the starting point of the next contour

--- a/ngc_exporter.hpp
+++ b/ngc_exporter.hpp
@@ -66,6 +66,7 @@ protected:
     bool bMetricoutput;     //if true, metric g-code output
     bool bZchangeG53;
     bool nom6; // missing m6
+    double min_path_length; // minimum path length to mill (skip Voronoi artifacts)
 
     bool bTile;
 

--- a/options.cpp
+++ b/options.cpp
@@ -295,7 +295,8 @@ options::options()
        ("path-finding-limit", po::value<size_t>()->default_value(1), "Use path finding for up to this many steps in the search (more is slower but makes a faster gcode path)")
        ("g0-vertical-speed", po::value<Velocity>()->default_value(parse_unit<Velocity>("50in/min")), "speed of vertical G0 movements, for use in path-finding")
        ("g0-horizontal-speed", po::value<Velocity>()->default_value(parse_unit<Velocity>("100in/min")), "speed of horizontal G0 movements, for use in path-finding")
-       ("backtrack", po::value<Velocity>()->default_value(std::numeric_limits<double>::infinity()), "allow retracing a milled path if it's faster than retract-move-lower.  For example, set to 5in/s if you are willing to remill 5 inches of trace in order to save 1 second of milling time.");
+       ("backtrack", po::value<Velocity>()->default_value(std::numeric_limits<double>::infinity()), "allow retracing a milled path if it's faster than retract-move-lower.  For example, set to 5in/s if you are willing to remill 5 inches of trace in order to save 1 second of milling time.")
+       ("min-path-length", po::value<Length>()->default_value(Length(0)), "Skip milling paths shorter than this length.  Useful for removing tiny Voronoi artifacts.  Set to 0.1mm to remove paths shorter than 0.1mm.");
    cfg_options.add(optimization_options);
 
    po::options_description autolevelling_options("Autolevelling options, for generating gcode to automatically probe the board and adjust milling depth to the actual board height");


### PR DESCRIPTION
Without this option, there are (quite literally) hundreds of tiny artifacts (even on a relatively small board) that cause a CNC machine to jump up and down during milling endlessly. By using `--min-path-length=0.1`, these are removed, speeding up the milling process -- and making it less restless and jumpy.