### PR TITLE
perf: Multi-threaded surface_vectorial

### DIFF
--- a/path_finding.cpp
+++ b/path_finding.cpp
@@ -329,10 +329,10 @@ boost::optional<RingIndices> outside_multipolygons(
    value will actually be a vector of size_t that indicates which
    rings in the stored polygon should be used for the generated points
    in the path and also for the collision detection. */
-const boost::optional<SearchKey>& PathFindingSurface::in_surface(point_type_fp p) const {
-  auto memoized_result = point_in_surface_memo.find(p);
-  if (memoized_result != point_in_surface_memo.cend()) {
-    return memoized_result->second;
+boost::optional<SearchKey> PathFindingSurface::in_surface(point_type_fp p) const {
+  auto memoized_result = point_in_surface_memo.get(p);
+  if (memoized_result) {
+    return *memoized_result;
   }
   boost::optional<RingIndices> maybe_ring_indices;
   if (total_keep_in_grown) {
@@ -341,19 +341,22 @@ const boost::optional<SearchKey>& PathFindingSurface::in_surface(point_type_fp p
     maybe_ring_indices = outside_multipolygons(p, keep_out_shrunk);
   }
   if (!maybe_ring_indices) {
-    return point_in_surface_memo.emplace(p, boost::none).first->second;
+    point_in_surface_memo.set(p, boost::none);
+    return boost::none;
   }
   const auto& ring_indices = *maybe_ring_indices;
   // Check if this one is already in the cache.
-  const auto& find_result = ring_indices_lookup.find(std::cref(ring_indices));
-  if (find_result != ring_indices_lookup.cend()) {
+  const auto& find_result = ring_indices_lookup.get(std::cref(ring_indices));
+  if (find_result) {
     // Found in the cache so we can use that.
-    return point_in_surface_memo.emplace(p, find_result->second).first->second;
+    point_in_surface_memo.set(p, *find_result);
+    return *find_result;
   }
   // Not found so we need to add it to the cache.
   ring_indices_cache.push_back(ring_indices);
-  ring_indices_lookup.emplace(ring_indices_cache.back(), ring_indices_cache.size()-1);
-  return point_in_surface_memo.emplace(p, ring_indices_cache.size()-1).first->second;
+  ring_indices_lookup.set(ring_indices_cache.back(), ring_indices_cache.size()-1);
+  point_in_surface_memo.set(p, ring_indices_cache.size()-1);
+  return ring_indices_cache.size()-1;
 }
 
 // Return true if this edge from a to b is part of the path finding surface.
@@ -363,12 +366,12 @@ bool PathFindingSurface::in_surface(
     return in_surface(b, a);
   }
   const auto key = make_pair(a, b);
-  auto memoized_result = edge_in_surface_memo.find(key);
-  if (memoized_result != edge_in_surface_memo.cend()) {
-    return memoized_result->second;
+  auto memoized_result = edge_in_surface_memo.get(key);
+  if (memoized_result) {
+    return *memoized_result;
   }
   auto found_intersection = tree.intersects(a, b);
-  edge_in_surface_memo.emplace(key, !found_intersection);
+  edge_in_surface_memo.set(key, !found_intersection);
   return !found_intersection;
 }
 
@@ -420,11 +423,11 @@ optional<linestring_type_fp> PathFindingSurface::find_path(
   return pfs_with_tries.find_path(start, goal, max_path_length, *ring_indices);
 }
 
-const std::vector<point_type_fp>&
+std::vector<point_type_fp>
 PathFindingSurface::vertices(SearchKey search_key) const {
-  auto memoized_result = vertices_memo.find(search_key);
-  if (memoized_result != vertices_memo.cend()) {
-    return memoized_result->second;
+  auto memoized_result = vertices_memo.get(search_key);
+  if (memoized_result) {
+    return *memoized_result;
   }
   std::vector<point_type_fp> ret;
   const auto& vertices = all_vertices;
@@ -440,7 +443,8 @@ PathFindingSurface::vertices(SearchKey search_key) const {
       ret.insert(ret.cend(), ring_vertices.cbegin(), ring_vertices.cend());
     }
   }
-  return vertices_memo.emplace(search_key, ret).first->second;
+  vertices_memo.set(search_key, ret);
+  return ret;
 }
 
 optional<linestring_type_fp> PathFindingSurfaceWithTries::find_path(

--- a/path_finding.hpp
+++ b/path_finding.hpp
@@ -1,8 +1,10 @@
 #ifndef PATH_FINDING_H
 #define PATH_FINDING_H
 
+#include <mutex>
+
 #include <boost/optional.hpp>
-#include <unordered_map>
+#include "thread_safe_unordered_map.hpp"
 
 #include "geometry.hpp"
 #include "bg_operators.hpp"
@@ -181,7 +183,7 @@ class PathFindingSurface {
   PathFindingSurface(const boost::optional<multi_polygon_type_fp>& keep_in,
                      const multi_polygon_type_fp& keep_out,
                      const coordinate_type_fp tolerance);
-  const boost::optional<SearchKey>& in_surface(point_type_fp p) const;
+  boost::optional<SearchKey> in_surface(point_type_fp p) const;
   // Find a path from start to goal in the available surface, limited
   // in operations.
   boost::optional<linestring_type_fp> find_path(
@@ -200,7 +202,7 @@ class PathFindingSurface {
   friend class Neighbors;
   friend class PathFindingSurfaceWithTries;
   multi_polygon_type_fp get_surface() const;
-  const std::vector<point_type_fp>& vertices(SearchKey search_key) const;
+  std::vector<point_type_fp> vertices(SearchKey search_key) const;
   bool in_surface(
       const point_type_fp& a, const point_type_fp& b) const;
 
@@ -214,16 +216,15 @@ class PathFindingSurface {
   // all_vertices is one list for each ring in the original.  The
   // lists are arranged in the same way as the RingIndices.
   std::vector<std::vector<std::vector<point_type_fp>>> all_vertices;
-  mutable std::unordered_map<std::pair<point_type_fp, point_type_fp>, bool> edge_in_surface_memo;
+  mutable ThreadSafeUnorderedMap<std::pair<point_type_fp, point_type_fp>, bool> edge_in_surface_memo;
   // RingIndices can be very large and slow to hash so we'll store
   // them here and elsewhere just store the index into this list.
   mutable std::vector<RingIndices> ring_indices_cache;
-  mutable std::unordered_map<RingIndices, size_t,
-                             std::hash<RingIndices>,
-                             std::equal_to<RingIndices>> ring_indices_lookup;
-  mutable std::unordered_map<point_type_fp, boost::optional<SearchKey>> point_in_surface_memo;
+  mutable std::mutex ring_indices_cache_mutex;
+  mutable ThreadSafeUnorderedMap<RingIndices, size_t> ring_indices_lookup;
+  mutable ThreadSafeUnorderedMap<point_type_fp, boost::optional<SearchKey>> point_in_surface_memo;
   segment_tree::SegmentTree tree;
-  mutable std::unordered_map<SearchKey, std::vector<point_type_fp>> vertices_memo;
+  mutable ThreadSafeUnorderedMap<SearchKey, std::vector<point_type_fp>> vertices_memo;
   mutable boost::optional<size_t> tries; // This is not great to be mutable.
 };
 
@@ -246,7 +247,7 @@ class PathFindingSurfaceWithTries {
    }
  private:
   friend class PathFindingSurface;
-  const std::vector<point_type_fp>& vertices(SearchKey search_key) const {
+  std::vector<point_type_fp> vertices(SearchKey search_key) const {
     return path_finding_surface.vertices(search_key);
   }
   boost::optional<linestring_type_fp> find_path(

--- a/surface_vectorial.cpp
+++ b/surface_vectorial.cpp
@@ -986,7 +986,7 @@ vector<pair<coordinate_type_fp, multi_linestring_type_fp>> Surface_vectorial::ge
       for (const auto& poly : vectorial_surface.first) {
         keep_outs.push_back(bg_helpers::buffer(poly, tool_diameter/2 + isolator->offset));
       }
-      const auto path_finding_surface = path_finding::PathFindingSurface(mask, sum(keep_outs), isolator->tolerance);
+      const path_finding::PathFindingSurface path_finding_surface(mask, sum(keep_outs), isolator->tolerance);
       std::vector<std::future<vector<pair<linestring_type_fp, bool>>>> trace_futures;
       bool multi_threaded = !options::get_vm()["single-thread"].as<bool>();
       for (size_t trace_index = 0; trace_index < trace_count; trace_index++) {
@@ -1078,7 +1078,7 @@ vector<pair<coordinate_type_fp, multi_linestring_type_fp>> Surface_vectorial::ge
   }
   auto cutter = dynamic_pointer_cast<Cutter>(mill);
   if (cutter) {
-    const auto path_finding_surface = path_finding::PathFindingSurface(multi_polygon_type_fp(), multi_polygon_type_fp(), cutter->tolerance);
+    const path_finding::PathFindingSurface path_finding_surface(multi_polygon_type_fp(), multi_polygon_type_fp(), cutter->tolerance);
     const auto trace_count = vectorial_surface.first.size();
     vector<vector<pair<linestring_type_fp, bool>>> new_trace_toolpaths(trace_count);
 

--- a/thread_safe_unordered_map.hpp
+++ b/thread_safe_unordered_map.hpp
@@ -1,0 +1,85 @@
+#ifndef THREAD_SAFE_UNORDERED_MAP_HPP
+#define THREAD_SAFE_UNORDERED_MAP_HPP
+
+#include <mutex>
+#include <unordered_map>
+
+#include <boost/optional.hpp>
+
+template <typename Key,
+          typename Value,
+          typename Hash = std::hash<Key>,
+          typename KeyEqual = std::equal_to<Key>>
+class ThreadSafeUnorderedMap {
+ public:
+  using key_type = Key;
+  using mapped_type = Value;
+  using map_type = std::unordered_map<Key, Value, Hash, KeyEqual>;
+
+  bool contains(const key_type& key) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return values_.find(key) != values_.cend();
+  }
+
+  boost::optional<mapped_type> get(const key_type& key) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto it = values_.find(key);
+    if (it == values_.cend()) {
+      return boost::none;
+    }
+    return it->second;
+  }
+
+  const mapped_type* find_ptr(const key_type& key) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto it = values_.find(key);
+    if (it == values_.cend()) {
+      return nullptr;
+    }
+    return &it->second;
+  }
+
+  template <typename ValueFactory>
+  const mapped_type& get_or_insert(
+      const key_type& key,
+      ValueFactory&& value_factory) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto it = values_.find(key);
+    if (it != values_.cend()) {
+      return it->second;
+    }
+    auto inserted = values_.emplace(key, std::forward<ValueFactory>(value_factory)());
+    return inserted.first->second;
+  }
+
+  void set(const key_type& key, const mapped_type& value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    values_[key] = value;
+  }
+
+  void set(const key_type& key, mapped_type&& value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    values_[key] = std::move(value);
+  }
+
+  bool erase(const key_type& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return values_.erase(key) > 0;
+  }
+
+  void clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    values_.clear();
+  }
+
+  std::size_t size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return values_.size();
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  map_type values_;
+};
+
+#endif // THREAD_SAFE_UNORDERED_MAP_HPP


### PR DESCRIPTION
Use multi-threading to improve the performance of surface_vectorial.  Each trace can be computed in parallel in a different thread.