### PR TITLE
build: use pull_request_target for release-drafter.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
   push:
     branches:
       - master


### PR DESCRIPTION
It needs this in order to work on PRs from different forks.