### PR TITLE
ci: Skip integration test based on Boost and GEOS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,9 +349,8 @@ jobs:
             fi
         done
     - name: >
-        Run unit tests 
-        ${{ matrix.code_coverage == '' && matrix.os == 'ubuntu' && 'with valgrind' || 'without valgrind' }} and
-        ${{ (matrix.boost != '1_83' || matrix.geos != '3.13.1') && 'without integration tests' || 'with integration tests' }}
+        Run unit tests
+        ${{ matrix.code_coverage == '' && matrix.os == 'ubuntu' && 'with valgrind' || 'without valgrind' }}
       env:
         VERBOSE: 1
       run: |
@@ -359,9 +358,6 @@ jobs:
         if [[ "${{ matrix.code_coverage }}" == "" && "${{ matrix.os }}" == "ubuntu" ]]; then
           export CTEST_MEMORYCHECK_COMMAND=valgrind
           CTEST_ARGS+=(-T memcheck)
-        fi
-        if [[ "${{ matrix.boost }}" != "1_83" || "${{ matrix.geos }}" != "3.13.1" ]]; then
-          CTEST_ARGS+=(-E '^(integration_tests)$')
         fi
         ctest "${CTEST_ARGS[@]}"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,11 +415,26 @@ if(BUILD_TESTING)
     segment_tree_tests.cpp
     segment_tree.cpp)
 
-  add_test(
-    NAME integration_tests
-    COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/integration/integration_tests.py"
-            --pcb2gcode-binary "$<TARGET_FILE:pcb2gcode>"
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+  # Integration tests require Boost 1.83 and GEOS 3.13.1 for reproducible results.
+  set(PCB2GCODE_RUN_INTEGRATION_TESTS OFF)
+  if(PCB2GCODE_HAS_GEOS
+     AND PCB2GCODE_GEOS_VERSION VERSION_EQUAL "3.13.1"
+     AND Boost_VERSION VERSION_EQUAL "1.83")
+    set(PCB2GCODE_RUN_INTEGRATION_TESTS ON)
+  endif()
+  if(PCB2GCODE_RUN_INTEGRATION_TESTS)
+    add_test(
+      NAME integration_tests
+      COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/integration/integration_tests.py"
+              --pcb2gcode-binary "$<TARGET_FILE:pcb2gcode>"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+  else()
+    set(_geos_display "${PCB2GCODE_GEOS_VERSION}")
+    if(NOT _geos_display)
+      set(_geos_display "none")
+    endif()
+    message(STATUS "Skipping integration_tests (require Boost 1.83 and GEOS 3.13.1, have Boost ${Boost_VERSION} and GEOS ${_geos_display})")
+  endif()
 
   if(PCB2GCODE_ENABLE_CODE_COVERAGE)
     get_property(PCB2GCODE_TEST_TARGETS GLOBAL PROPERTY PCB2GCODE_TEST_TARGETS)


### PR DESCRIPTION
* Modified: CMakeLists.txt to conditionally run integration tests only if Boost 1.83 and GEOS 3.13.1 are available.
* Added: status messages to indicate when tests are skipped due to version mismatches.
* Updated: CI workflow to remove unnecessary checks for integration tests.

This fixes #828.