### PR TITLE
ci: Run examples for Windows and Linux.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       if: matrix.os == 'ubuntu'
       run: |
         sudo apt-get update
-        sudo apt-get install libgtkmm-2.4-dev moreutils autopoint libc6-dbg librsvg2-dev parallel ccache g++
+        sudo apt-get install libgtkmm-2.4-dev moreutils autopoint libc6-dbg librsvg2-dev ccache g++
         sudo apt-get install libperlio-gzip-perl libjson-perl libcapture-tiny-perl libjson-xs-perl libdatetime-perl python3-setuptools
         pip3 install --user wheel colour_runner unittest2 termcolor concurrencytest
 
@@ -277,7 +277,7 @@ jobs:
     - name: Install valgrind
       if: matrix.os == 'ubuntu'
       run: |
-        if ! valgrind --version || ! grep -qx "$(git ls-remote git://sourceware.org/git/valgrind.git master)" ${LOCAL_INSTALL_PATH}/bin/valgrind.version; then
+        if ! valgrind --version; then
           git ls-remote git://sourceware.org/git/valgrind.git master > ${LOCAL_INSTALL_PATH}/bin/valgrind.version
           echo "UPDATE_CACHE=true" >> $GITHUB_ENV
           pushd ~
@@ -324,25 +324,20 @@ jobs:
         echo "PCB2GCODE_VERSION=$PCB2GCODE_VERSION" >> $GITHUB_ENV
 
 ### Run examples.  Don't run them if code_coverage is set because they are too slow.  Only on ubuntu because it has valgrind.
-    - name: Run examples with valgrind
-      if: (github.event_name == 'schedule' || inputs.examples_enabled == true) && matrix.code_coverage == '' && matrix.os == 'ubuntu'
+    - name: Run examples
+      if: (github.event_name == 'schedule' || inputs.examples_enabled == true)
       run: |
-        pushd tests/data/gerbv_example
-        ls | parallel -k -j ${NUM_CPUS} --halt soon,fail=1 '
-          { echo "::group::Running on {}";
-            pushd {};
-            if [[ -f "no-valgrind" ]]; then
-              cat no-valgrind;
-            fi;
-            if [[ -f "no-valgrind" || "${{ matrix.os }}" != "ubuntu" ]]; then
-              time ../../../../build/pcb2gcode || exit;
-            else
-              time valgrind --error-exitcode=127 --errors-for-leak-kinds=definite --leak-check=full -s --exit-on-first-error=yes --expensive-definedness-checks=yes -- ../../../../build/pcb2gcode || exit;
-            fi;
-            popd;
-            echo "::endgroup::";
-          } 2>&1'
-        popd
+        if [[ -n "${{ matrix.code_coverage }}" ]]; then
+          code_coverage_arg="--code-coverage";
+        else
+          code_coverage_arg="";
+        fi
+        if [[ -f ./build/pcb2gcode.exe ]]; then
+          pcb2gcode_binary="./build/pcb2gcode.exe";
+        else
+          pcb2gcode_binary="./build/pcb2gcode";
+        fi
+        ls -d tests/data/gerbv_example/* | ./tools/parallel.py -j ${NUM_CPUS} --halt now -- python ./tests/integration/run_example.py '{}' --pcb2gcode-binary $pcb2gcode_binary $code_coverage_arg
     - name: >
         Run unit tests
         ${{ matrix.code_coverage == '' && matrix.os == 'ubuntu' && 'with valgrind' || 'without valgrind' }}

--- a/tests/integration/run_example.py
+++ b/tests/integration/run_example.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Run pcb2gcode on an example directory, optionally under valgrind."""
+
+import argparse
+import os
+import sys
+import time
+import shutil
+import subprocess
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run pcb2gcode on an example directory, optionally under valgrind."
+    )
+    parser.add_argument(
+        "--code-coverage",
+        action="store_true",
+        help="Code coverage is enabled (skip valgrind as it makes pcb2gcode too slow)",
+    )
+    parser.add_argument(
+        "--pcb2gcode-binary",
+        required=True,
+        help="Path to pcb2gcode binary to run.",
+    )
+    parser.add_argument(
+        "example_dir",
+        help="Example directory to run (e.g. a subdir of tests/data/gerbv_example)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    example_dir = args.example_dir
+    code_coverage_enabled = args.code_coverage
+    pcb2gcode_binary = args.pcb2gcode_binary
+    pcb2gcode_binary = os.path.abspath(pcb2gcode_binary)
+
+    have_valgrind = shutil.which("valgrind") is not None
+    return_code = 0
+    try:
+        if os.path.isfile(os.path.join(example_dir, "no-valgrind")):
+            with open(os.path.join(example_dir, "no-valgrind")) as f:
+                valgrind_disabled_reason = f.read()
+        else:
+            valgrind_disabled_reason = None
+        run_with_valgrind = (not valgrind_disabled_reason and
+                             have_valgrind and
+                             not code_coverage_enabled)
+        print(f'::group::Running {"with valgrind" if run_with_valgrind else "without valgrind"} on {example_dir}')
+        if valgrind_disabled_reason:
+            print(f"valgrind is disabled: {valgrind_disabled_reason}")
+        elif not have_valgrind:
+            print("valgrind is not installed; running pcb2gcode without valgrind")
+        elif code_coverage_enabled:
+            print("code coverage is enabled and that makes pcb2gcode too slow; running pcb2gcode without valgrind")
+
+        if not os.path.isfile(pcb2gcode_binary):
+            sys.exit(f"pcb2gcode not found: {pcb2gcode_binary}")
+
+        if run_with_valgrind:
+            cmd = [
+                "valgrind",
+                "--error-exitcode=127",
+                "--errors-for-leak-kinds=definite",
+                "--leak-check=full",
+                "-s",
+                "--exit-on-first-error=yes",
+                "--expensive-definedness-checks=yes",
+                "--",
+                pcb2gcode_binary,
+            ]
+        else:
+            cmd = [pcb2gcode_binary]
+
+        start = time.perf_counter()
+        result = subprocess.run(cmd, cwd=example_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        print(result.stdout, end="")
+        return_code = result.returncode
+        elapsed = time.perf_counter() - start
+        print(f"real {elapsed:.3f} seconds")
+        if return_code != 0:
+            print(f"::error file={example_dir}::pcb2gcode failed with return code {return_code}")
+    finally:
+        print("::endgroup::")
+    sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/parallel.py
+++ b/tools/parallel.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+import os
+import shlex
+import sys
+import argparse
+import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
+
+
+def build_cmd(command_template: list[str], argument: str) -> list[str] | None:
+    """Build the command list for the given argument. Returns None if argument is empty."""
+    argument = argument.strip()
+    if not argument:
+        return None
+    if any("{}" in part for part in command_template):
+        return [part.replace("{}", argument) for part in command_template]
+    return command_template + [argument]
+
+
+def run_command(command_template: list[str], argument: str, index: Any) -> tuple[dict[str, str] | None, Any]:
+    """Executes a single command with the given argument."""
+    cmd = build_cmd(command_template, argument)
+    if cmd is None:
+        return (None, index)
+    try:
+        # Capture output so stdout/stderr from different threads don't interleave
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        return {
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "returncode": result.returncode
+        }, index
+    except Exception as e:
+        return {
+            "stdout": "",
+            "stderr": f"Error executing '{' '.join(cmd)}': {e}\n",
+            "returncode": -1
+        }, index
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="A lightweight Python clone of GNU Parallel."
+    )
+    parser.add_argument(
+        "-j", "--jobs",
+        type=int,
+        default=0,
+        help="Number of concurrent jobs. Default is based on CPU count."
+    )
+    parser.add_argument(
+        "-k", "--keep-order",
+        action="store_true",
+        help="Keep same order. If set, print outputs in input order; if not, print in completion order."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the command that would be run for each input instead of running it."
+    )
+    parser.add_argument(
+        "--halt",
+        choices=["now", "soon", "never"],
+        default="never",
+        help="On failure: 'now' = stop all and exit; 'soon' = stop starting new jobs, let running finish; 'never' = run all (default)."
+    )
+    parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="The command to run. Use {} as a placeholder."
+    )
+
+    args = parser.parse_args()
+
+    # argparse includes the "--" delimiter in REMAINDER; strip it when passing to the command
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+
+    if not args.command:
+        parser.error("You must provide a command to execute.")
+
+    # If 0 or not provided, use same default as ThreadPoolExecutor (needed for --halt soon)
+    if args.jobs > 0:
+        max_workers = args.jobs
+    else:
+        max_workers = min(32, (os.cpu_count() or 1) + 4)
+
+    if sys.stdin.isatty():
+        print("Warning: Waiting for input from standard input (Ctrl+D to end)...", file=sys.stderr)
+
+    # Read all inputs from stdin
+    inputs = sys.stdin.read().splitlines()
+
+    if args.dry_run:
+        for line in inputs:
+            cmd = build_cmd(args.command, line)
+            if cmd is not None:
+                print(shlex.join(cmd))
+        return
+
+    def print_result(res: dict[str, str] | None) -> None:
+        if res:
+            if res["stdout"]:
+                sys.stdout.write(res["stdout"])
+                sys.stdout.flush()
+            if res["stderr"]:
+                sys.stderr.write(res["stderr"])
+                sys.stderr.flush()
+
+    # Filter to inputs that produce a command (skip blank lines)
+    work_items = [line for line in inputs if build_cmd(args.command, line) is not None]
+    if not work_items:
+        return
+
+    # We use ThreadPoolExecutor because subprocesses inherently bypass the Global Interpreter Lock (GIL)
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        stop_submitting = False # Whether to stop submitting new jobs.
+        pending = set() # A set of futures to wait on.
+        exit_code = 0
+        next_to_print = 0 # The index of the next result to print.
+        to_print = {} # A dictionary of indices to results to print.
+        work_iter = iter(enumerate(work_items))
+        while True:
+            # Submit more work while we have capacity and no failure yet
+            while not stop_submitting and len(pending) < max_workers:
+                try:
+                    index, arg = next(work_iter)
+                except StopIteration:
+                    break
+                pending.add(executor.submit(run_command, args.command, arg, index))
+
+            if not pending:
+                break
+            # Wait for any future to complete
+            future = next(iter(as_completed(pending)))
+            res, index = future.result()
+            pending.discard(future)
+            if res and res.get("returncode", 0) != 0:
+                exit_code = res["returncode"]
+                if args.halt == "now":
+                    # Cancel all pending futures, print the failure output, and exit.
+                    for f in pending:
+                        f.cancel()
+                    for available_to_print in sorted(to_print.keys()):
+                        print_result(to_print[available_to_print])
+                        del to_print[available_to_print]
+                    break
+                if args.halt == "soon":
+                    # Stop submitting new jobs.
+                    stop_submitting = True
+            if args.keep_order:
+                # Put them into the to_print dictionary and only print them in order.
+                to_print[index] = res
+                # Print as many as possible such that they are in the correct order.
+                while next_to_print in to_print:
+                    res = to_print[next_to_print]
+                    print_result(res)
+                    del to_print[next_to_print]
+                    next_to_print += 1
+            else:
+                # Print the result immediately.
+                print_result(res)
+        sys.exit(exit_code)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The examples only run on schedule, not for each PR.  They use valgrind when possible.  It works on Windows, too.  There is an option in the workflow to force them to run.