### PR TITLE
chore(ci): update geos version to 'main' in CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         os: [ubuntu, windows]
         boost: ['latest', '1_83']
         geos:
-          - &geos_version '3.14.1'
+          - &geos_version 'main'
           - 'none'
         compiler: ['g++', 'clang++', 'g++-10']
         exclude:


### PR DESCRIPTION
This is to fix the error solved in https://github.com/libgeos/geos/pull/1434