### PR TITLE
build: Require C++17 for GEOS 3.14+ header compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ include(GNUInstallDirs)
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 option(PCB2GCODE_WITH_GEOS "Enable GEOS support when available" ON)


### PR DESCRIPTION
GEOS main now uses C++17 nested namespace syntax; compiling pcb2gcode as C++14 triggers -Wc++17-extensions under -Werror.
